### PR TITLE
fix typo 'namesoace' to 'namespace'

### DIFF
--- a/src/manual/en_US/book.xml
+++ b/src/manual/en_US/book.xml
@@ -23462,7 +23462,7 @@ or
             deducted from the node's name
             (<literal><replaceable>node</replaceable>?node_name</literal>) and
             namespace
-            (<literal><replaceable>node</replaceable>?node_namesoace</literal>).
+            (<literal><replaceable>node</replaceable>?node_namespace</literal>).
             The rules of name deduction:</para>
 
             <itemizedlist>

--- a/src/manual/zh_CN/book.xml
+++ b/src/manual/zh_CN/book.xml
@@ -17482,7 +17482,7 @@ ${1.2}</programlisting>
 			它看上去像用户自定义指令(比如宏)来调用从结点名称
 			(<literal><replaceable>node</replaceable>?node_name</literal>)
 			和命名空间
-			(<literal><replaceable>node</replaceable>?node_namesoace</literal>)
+			(<literal><replaceable>node</replaceable>?node_namespace</literal>)
 			中有名称扣除的结点。名称扣除的规则：</para>
 
             <itemizedlist>


### PR DESCRIPTION
Fix typo 'namesoace' to 'namespace' in `src/manual/en_US/book.xml` and `src/manual/zh_CN/book.xml`.

Typo was found on this page: https://freemarker.apache.org/docs/ref_directive_visit.html