### PR TITLE
clearClassIntrospecitonCache typo correction

### DIFF
--- a/src/main/java/freemarker/ext/beans/BeansWrapper.java
+++ b/src/main/java/freemarker/ext/beans/BeansWrapper.java
@@ -673,7 +673,7 @@ public class BeansWrapper implements RichObjectWrapper, WriteProtectable {
     
     /**
      * Tells if this instance acts like if its class introspection cache is sharable with other {@link BeansWrapper}-s.
-     * A restricted cache denies certain too "antisocial" operations, like {@link #clearClassIntrospecitonCache()}.
+     * A restricted cache denies certain too "antisocial" operations, like {@link #clearClassIntrospectionCache()}.
      * The value depends on how the instance
      * was created; with a public constructor (then this is {@code false}), or with {@link BeansWrapperBuilder}
      * (then it's {@code true}). Note that in the last case it's possible that the introspection cache
@@ -1617,6 +1617,7 @@ public class BeansWrapper implements RichObjectWrapper, WriteProtectable {
     }
     
     /**
+     * @deprecated Use {@link #clearClassIntrospectionCache()};
      * Removes all class introspection data from the cache.
      * 
      * <p>Use this if you want to free up memory on the expense of recreating
@@ -1626,10 +1627,25 @@ public class BeansWrapper implements RichObjectWrapper, WriteProtectable {
      * 
      * @since 2.3.20
      */
+    @Deprecated
     public void clearClassIntrospecitonCache() {
         classIntrospector.clearCache();
     }
-    
+
+    /**
+     * Removes all class introspection data from the cache.
+     *
+     * <p>Use this if you want to free up memory on the expense of recreating
+     * the cache entries for the classes that will be used later in templates.
+     *
+     * @throws IllegalStateException if {@link #isClassIntrospectionCacheRestricted()} is {@code true}.
+     *
+     * @since 2.3.29
+     */
+    public void clearClassIntrospectionCache() {
+        classIntrospector.clearCache();
+    }
+
     ClassIntrospector getClassIntrospector() {
         return classIntrospector;
     }

--- a/src/main/java/freemarker/ext/beans/ClassIntrospector.java
+++ b/src/main/java/freemarker/ext/beans/ClassIntrospector.java
@@ -860,7 +860,7 @@ class ClassIntrospector {
     // Cache management:
 
     /**
-     * Corresponds to {@link BeansWrapper#clearClassIntrospecitonCache()}.
+     * Corresponds to {@link BeansWrapper#clearClassIntrospectionCache()}.
      * 
      * @since 2.3.20
      */

--- a/src/main/java/freemarker/template/Configuration.java
+++ b/src/main/java/freemarker/template/Configuration.java
@@ -646,7 +646,7 @@ public class Configuration extends Configurable implements Cloneable, ParserConf
      *         cache) because the singleton is modified after publishing to other threads.)
      *         Furthermore the new default object wrapper shares class introspection cache with other
      *         {@link BeansWrapper}-s created with {@link BeansWrapperBuilder}, which has an impact as
-     *         {@link BeansWrapper#clearClassIntrospecitonCache()} will be disallowed; see more about it there.
+     *         {@link BeansWrapper#clearClassIntrospectionCache()} will be disallowed; see more about it there.
      *       </li>
      *       <li><p>
      *          The {@code ?iso_...} built-ins won't show the time zone offset for {@link java.sql.Time} values anymore,

--- a/src/test/java/freemarker/ext/beans/AbstractParallelIntrospectionTest.java
+++ b/src/test/java/freemarker/ext/beans/AbstractParallelIntrospectionTest.java
@@ -83,7 +83,7 @@ public abstract class AbstractParallelIntrospectionTest extends TestCase {
             try {
                 for (int i = 0; i < iterations; i++) {
                     if (Math.random() < CACHE_CLEARING_CHANCE) {
-                        beansWrapper.clearClassIntrospecitonCache();
+                        beansWrapper.clearClassIntrospectionCache();
                     }
                     int objIdx = (int) (Math.random() * NUM_ENTITYES);
                     TemplateHashModel h = getWrappedEntity(objIdx);

--- a/src/test/java/freemarker/ext/beans/EnumModelsTest.java
+++ b/src/test/java/freemarker/ext/beans/EnumModelsTest.java
@@ -63,7 +63,7 @@ public class EnumModelsTest {
         
         assertSame(e, enums.get(E.class.getName()));
         
-        bw.clearClassIntrospecitonCache();
+        bw.clearClassIntrospectionCache();
         TemplateHashModel eAfterClean = (TemplateHashModel) enums.get(E.class.getName());
         assertNotSame(e, eAfterClean);
         assertSame(eAfterClean, enums.get(E.class.getName()));

--- a/src/test/java/freemarker/ext/beans/ModelCacheTest.java
+++ b/src/test/java/freemarker/ext/beans/ModelCacheTest.java
@@ -56,7 +56,7 @@ public class ModelCacheTest {
         TemplateModel wrappedC = bw.wrap(c);
         assertSame(wrappedC, bw.wrap(c));
         
-        bw.clearClassIntrospecitonCache();
+        bw.clearClassIntrospectionCache();
         assertNotSame(wrappedC, bw.wrap(c));
         assertSame(bw.wrap(c), bw.wrap(c));
     }

--- a/src/test/java/freemarker/ext/beans/StaticModelsTest.java
+++ b/src/test/java/freemarker/ext/beans/StaticModelsTest.java
@@ -70,7 +70,7 @@ public class StaticModelsTest {
         
         assertSame(s, statics.get(S.class.getName()));
         
-        bw.clearClassIntrospecitonCache();
+        bw.clearClassIntrospectionCache();
         TemplateHashModel sAfterClean = (TemplateHashModel) statics.get(S.class.getName());
         assertNotSame(s, sAfterClean);
         assertSame(sAfterClean, statics.get(S.class.getName()));


### PR DESCRIPTION
BeansWrapper method clearClassIntrospecitonCache contains a typo. Added clearClassIntrospectionCache and marked the misspelled method as deprecated