### PR TITLE
fix constructor of ExtendedDecimalFormatParser

### DIFF
--- a/src/main/java/freemarker/core/ExtendedDecimalFormatParser.java
+++ b/src/main/java/freemarker/core/ExtendedDecimalFormatParser.java
@@ -479,7 +479,7 @@ class ExtendedDecimalFormatParser {
 
     private ExtendedDecimalFormatParser(String formatString, Locale locale) {
         src = formatString;
-        this.symbols = new DecimalFormatSymbols(locale);
+        this.symbols = DecimalFormatSymbols.getInstance(locale);
     }
 
     private ParseException newExpectedSgParseException(String expectedThing) {


### PR DESCRIPTION
use DecimalFormatSymbols.getInstance(locale) instead of the constructor
to properly work with other DecimalFormatSymbolsProvider implementations.

See https://issues.apache.org/jira/browse/FREEMARKER-125 