### PR TITLE
Freemarker 35

### DIFF
--- a/src/main/java/freemarker/core/BuiltInsForMultipleTypes.java
+++ b/src/main/java/freemarker/core/BuiltInsForMultipleTypes.java
@@ -46,6 +46,7 @@ import freemarker.template.TemplateNodeModel;
 import freemarker.template.TemplateNumberModel;
 import freemarker.template.TemplateScalarModel;
 import freemarker.template.TemplateSequenceModel;
+import freemarker.template.TemplateTemporalModel;
 import freemarker.template.TemplateTransformModel;
 import freemarker.template._TemplateAPI;
 import freemarker.template.utility.NumberUtil;
@@ -605,6 +606,69 @@ class BuiltInsForMultipleTypes {
             }
         }
     
+
+        private class TemporalFormatter implements TemplateScalarModel, TemplateHashModel, TemplateMethodModel {
+            private final TemplateTemporalModel temporalModel;
+            private final Environment env;
+            private final TemplateTemporalFormat defaultFormat;
+            private String cachedValue;
+
+            TemporalFormatter(TemplateTemporalModel temporalModel, Environment env) throws TemplateException {
+                this.temporalModel = temporalModel;
+                this.env = env;
+                this.defaultFormat = env.getTemplateTemporalFormat();
+            }
+
+            @Override
+            public Object exec(List args) throws TemplateModelException {
+                checkMethodArgCount(args, 1);
+                return formatWith((String) args.get(0));
+            }
+
+            @Override
+            public TemplateModel get(String key) throws TemplateModelException {
+                return formatWith(key);
+            }
+
+            private TemplateModel formatWith(String key)
+                    throws TemplateModelException {
+                try {
+                    return new SimpleScalar(env.formatTemporalToPlainText(temporalModel, key, target));
+                } catch (TemplateException e) {
+                    // `e` should always be a TemplateModelException here, but to be sure:
+                    throw _CoreAPI.ensureIsTemplateModelException("Failed to format value", e);
+                } catch (TemplateValueFormatException e) {
+                    throw new _TemplateModelException("Failed to format value", e);
+                }
+            }
+
+            @Override
+            public String getAsString() throws TemplateModelException {
+                if (cachedValue == null) {
+                    if (defaultFormat == null) {
+                        throw new BugException();
+                    }
+                    try {
+                        cachedValue = EvalUtil.assertFormatResultNotNull(defaultFormat.format(temporalModel));
+                    } catch (TemplateValueFormatException e) {
+                        try {
+                            throw _MessageUtil.newCantFormatDateException(defaultFormat, target, e, true);
+                        } catch (TemplateException e2) {
+                            // `e` should always be a TemplateModelException here, but to be sure:
+                            throw _CoreAPI.ensureIsTemplateModelException("Failed to format date/time/datetime", e2);
+                        }
+                    }
+                }
+                return cachedValue;
+            }
+
+            @Override
+            public boolean isEmpty() {
+                return false;
+            }
+        }
+
+
         private class DateFormatter
         implements
             TemplateScalarModel,
@@ -768,6 +832,9 @@ class BuiltInsForMultipleTypes {
             } else if (model instanceof TemplateDateModel) {
                 TemplateDateModel dm = (TemplateDateModel) model;
                 return new DateFormatter(dm, env);
+            } else if (model instanceof TemplateTemporalModel) {
+                TemplateTemporalModel tm = (TemplateTemporalModel) model;
+                return new TemporalFormatter(tm, env);
             } else if (model instanceof SimpleScalar) {
                 return model;
             } else if (model instanceof TemplateBooleanModel) {

--- a/src/main/java/freemarker/core/BuiltInsForMultipleTypes.java
+++ b/src/main/java/freemarker/core/BuiltInsForMultipleTypes.java
@@ -616,7 +616,7 @@ class BuiltInsForMultipleTypes {
             TemporalFormatter(TemplateTemporalModel temporalModel, Environment env) throws TemplateException {
                 this.temporalModel = temporalModel;
                 this.env = env;
-                this.defaultFormat = env.getTemplateTemporalFormat();
+                this.defaultFormat = env.getTemplateTemporalFormat(temporalModel.getAsTemporal());
             }
 
             @Override

--- a/src/main/java/freemarker/core/Configurable.java
+++ b/src/main/java/freemarker/core/Configurable.java
@@ -1404,24 +1404,24 @@ public class Configurable {
         return zonedDateTimeFormat == null ? parent.getZonedDateTimeFormat() : zonedDateTimeFormat;
     }
 
-    public String getTemporalFormat(Temporal temporal) {
-        if (temporal instanceof Instant) {
+    public String getTemporalFormat(Class<? extends Temporal> temporalClass) {
+        if (temporalClass == Instant.class) {
             return getInstantFormat();
-        } else if (temporal instanceof LocalDate) {
+        } else if (temporalClass == LocalDate.class) {
             return getLocalDateFormat();
-        } else if (temporal instanceof LocalDateTime) {
+        } else if (temporalClass == LocalDateTime.class) {
             return getLocalDateTimeFormat();
-        } else if (temporal instanceof LocalTime) {
+        } else if (temporalClass == LocalTime.class) {
             return getLocalTimeFormat();
-        } else if (temporal instanceof OffsetDateTime) {
+        } else if (temporalClass == OffsetDateTime.class) {
             return getOffsetDateTimeFormat();
-        } else if (temporal instanceof OffsetTime) {
+        } else if (temporalClass == OffsetTime.class) {
             return getOffsetTimeFormat();
-        } else if (temporal instanceof Year) {
+        } else if (temporalClass == Year.class) {
             return getYearFormat();
-        } else if (temporal instanceof YearMonth) {
+        } else if (temporalClass == YearMonth.class) {
             return getYearMonthFormat();
-        } else if (temporal instanceof ZonedDateTime) {
+        } else if (temporalClass == ZonedDateTime.class) {
             return getZonedDateTimeFormat();
         } else {
             return "";

--- a/src/main/java/freemarker/core/Configurable.java
+++ b/src/main/java/freemarker/core/Configurable.java
@@ -24,6 +24,16 @@ import java.io.InputStream;
 import java.io.Writer;
 import java.text.NumberFormat;
 import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.time.Year;
+import java.time.YearMonth;
+import java.time.ZonedDateTime;
+import java.time.temporal.Temporal;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -138,9 +148,41 @@ public class Configurable {
     /** Alias to the {@code ..._SNAKE_CASE} variation due to backward compatibility constraints. */
     public static final String DATETIME_FORMAT_KEY = DATETIME_FORMAT_KEY_SNAKE_CASE;
 
-    public static final String TEMPORAL_FORMAT_KEY_SNAKE_CASE = "temporal_format";
-    public static final String TEMPORAL_FORMAT_KEY_CAMEL_CASE = "temporalFormat";
-    public static final String TEMPORAL_FORMAT_KEY = TEMPORAL_FORMAT_KEY_SNAKE_CASE;
+    public static final String INSTANT_FORMAT_KEY_SNAKE_CASE = "instant_format";
+    public static final String INSTANT_FORMAT_KEY_CAMEL_CASE = "instantFormat";
+    public static final String INSTANT_FORMAT_KEY = INSTANT_FORMAT_KEY_SNAKE_CASE;
+
+    public static final String LOCALDATE_FORMAT_KEY_SNAKE_CASE = "localdate_format";
+    public static final String LOCALDATE_FORMAT_KEY_CAMEL_CASE = "localdateFormat";
+    public static final String LOCALDATE_FORMAT_KEY = LOCALDATE_FORMAT_KEY_SNAKE_CASE;
+
+    public static final String LOCALDATETIME_FORMAT_KEY_SNAKE_CASE = "localdatetime_format";
+    public static final String LOCALDATETIME_FORMAT_KEY_CAMEL_CASE = "localdatetimeFormat";
+    public static final String LOCALDATETIME_FORMAT_KEY = LOCALDATETIME_FORMAT_KEY_SNAKE_CASE;
+
+    public static final String LOCALTIME_FORMAT_KEY_SNAKE_CASE = "localtime_format";
+    public static final String LOCALTIME_FORMAT_KEY_CAMEL_CASE = "localtimeFormat";
+    public static final String LOCALTIME_FORMAT_KEY = LOCALTIME_FORMAT_KEY_SNAKE_CASE;
+
+    public static final String OFFSETDATETIME_FORMAT_KEY_SNAKE_CASE = "offsetdatetime_format";
+    public static final String OFFSETDATETIME_FORMAT_KEY_CAMEL_CASE = "offsetdatetimeFormat";
+    public static final String OFFSETDATETIME_FORMAT_KEY = OFFSETDATETIME_FORMAT_KEY_SNAKE_CASE;
+
+    public static final String OFFSETTIME_FORMAT_KEY_SNAKE_CASE = "offsettime_format";
+    public static final String OFFSETTIME_FORMAT_KEY_CAMEL_CASE = "offsettimeFormat";
+    public static final String OFFSETTIME_FORMAT_KEY = OFFSETTIME_FORMAT_KEY_SNAKE_CASE;
+
+    public static final String YEAR_FORMAT_KEY_SNAKE_CASE = "year_format";
+    public static final String YEAR_FORMAT_KEY_CAMEL_CASE = "yearFormat";
+    public static final String YEAR_FORMAT_KEY = YEAR_FORMAT_KEY_SNAKE_CASE;
+
+    public static final String YEARMONTH_FORMAT_KEY_SNAKE_CASE = "yearmonth_format";
+    public static final String YEARMONTH_FORMAT_KEY_CAMEL_CASE = "yearmonthFormat";
+    public static final String YEARMONTH_FORMAT_KEY = YEARMONTH_FORMAT_KEY_SNAKE_CASE;
+
+    public static final String ZONEDDATETIME_FORMAT_KEY_SNAKE_CASE = "zoneddatetime_format";
+    public static final String ZONEDDATETIME_FORMAT_KEY_CAMEL_CASE = "zoneddatetimeFormat";
+    public static final String ZONEDDATETIME_FORMAT_KEY = ZONEDDATETIME_FORMAT_KEY_SNAKE_CASE;
 
     /** Legacy, snake case ({@code like_this}) variation of the setting name. @since 2.3.23 */
     public static final String TIME_ZONE_KEY_SNAKE_CASE = "time_zone";
@@ -314,26 +356,34 @@ public class Configurable {
         CUSTOM_NUMBER_FORMATS_KEY_SNAKE_CASE,
         DATE_FORMAT_KEY_SNAKE_CASE,
         DATETIME_FORMAT_KEY_SNAKE_CASE,
+        INSTANT_FORMAT_KEY_SNAKE_CASE,
         LAZY_AUTO_IMPORTS_KEY_SNAKE_CASE,
         LAZY_IMPORTS_KEY_SNAKE_CASE,
+        LOCALDATE_FORMAT_KEY_SNAKE_CASE,
+        LOCALDATETIME_FORMAT_KEY_SNAKE_CASE,
         LOCALE_KEY_SNAKE_CASE,
+        LOCALTIME_FORMAT_KEY_SNAKE_CASE,
         LOG_TEMPLATE_EXCEPTIONS_KEY_SNAKE_CASE,
         NEW_BUILTIN_CLASS_RESOLVER_KEY_SNAKE_CASE,
         NUMBER_FORMAT_KEY_SNAKE_CASE,
         OBJECT_WRAPPER_KEY_SNAKE_CASE,
+        OFFSETDATETIME_FORMAT_KEY_SNAKE_CASE,
+        OFFSETTIME_FORMAT_KEY_SNAKE_CASE,
         OUTPUT_ENCODING_KEY_SNAKE_CASE,
         SHOW_ERROR_TIPS_KEY_SNAKE_CASE,
         SQL_DATE_AND_TIME_TIME_ZONE_KEY_SNAKE_CASE,
         STRICT_BEAN_MODELS_KEY,
         TEMPLATE_EXCEPTION_HANDLER_KEY_SNAKE_CASE,
-        TEMPORAL_FORMAT_KEY_SNAKE_CASE,
         TIME_FORMAT_KEY_SNAKE_CASE,
         TIME_ZONE_KEY_SNAKE_CASE,
         TRUNCATE_BUILTIN_ALGORITHM_KEY_SNAKE_CASE,
         URL_ESCAPING_CHARSET_KEY_SNAKE_CASE,
-        WRAP_UNCHECKED_EXCEPTIONS_KEY_SNAKE_CASE
+        WRAP_UNCHECKED_EXCEPTIONS_KEY_SNAKE_CASE,
+        YEAR_FORMAT_KEY_SNAKE_CASE,
+        YEARMONTH_FORMAT_KEY_SNAKE_CASE,
+        ZONEDDATETIME_FORMAT_KEY_SNAKE_CASE
     };
-    
+
     private static final String[] SETTING_NAMES_CAMEL_CASE = new String[] {
         // Must be sorted alphabetically!
         API_BUILTIN_ENABLED_KEY_CAMEL_CASE,
@@ -348,24 +398,32 @@ public class Configurable {
         CUSTOM_NUMBER_FORMATS_KEY_CAMEL_CASE,
         DATE_FORMAT_KEY_CAMEL_CASE,
         DATETIME_FORMAT_KEY_CAMEL_CASE,
+        INSTANT_FORMAT_KEY_CAMEL_CASE,
         LAZY_AUTO_IMPORTS_KEY_CAMEL_CASE,
         LAZY_IMPORTS_KEY_CAMEL_CASE,
+        LOCALDATE_FORMAT_KEY_CAMEL_CASE,
+        LOCALDATETIME_FORMAT_KEY_CAMEL_CASE,
         LOCALE_KEY_CAMEL_CASE,
+        LOCALTIME_FORMAT_KEY_CAMEL_CASE,
         LOG_TEMPLATE_EXCEPTIONS_KEY_CAMEL_CASE,
         NEW_BUILTIN_CLASS_RESOLVER_KEY_CAMEL_CASE,
         NUMBER_FORMAT_KEY_CAMEL_CASE,
         OBJECT_WRAPPER_KEY_CAMEL_CASE,
+        OFFSETDATETIME_FORMAT_KEY_CAMEL_CASE,
+        OFFSETTIME_FORMAT_KEY_CAMEL_CASE,
         OUTPUT_ENCODING_KEY_CAMEL_CASE,
         SHOW_ERROR_TIPS_KEY_CAMEL_CASE,
         SQL_DATE_AND_TIME_TIME_ZONE_KEY_CAMEL_CASE,
         STRICT_BEAN_MODELS_KEY_CAMEL_CASE,
         TEMPLATE_EXCEPTION_HANDLER_KEY_CAMEL_CASE,
-        TEMPORAL_FORMAT_KEY_CAMEL_CASE,
         TIME_FORMAT_KEY_CAMEL_CASE,
         TIME_ZONE_KEY_CAMEL_CASE,
         TRUNCATE_BUILTIN_ALGORITHM_KEY_CAMEL_CASE,
         URL_ESCAPING_CHARSET_KEY_CAMEL_CASE,
-        WRAP_UNCHECKED_EXCEPTIONS_KEY_CAMEL_CASE
+        WRAP_UNCHECKED_EXCEPTIONS_KEY_CAMEL_CASE,
+        YEAR_FORMAT_KEY_CAMEL_CASE,
+        YEARMONTH_FORMAT_KEY_CAMEL_CASE,
+        ZONEDDATETIME_FORMAT_KEY_CAMEL_CASE
     };
 
     private Configurable parent;
@@ -377,7 +435,15 @@ public class Configurable {
     private String timeFormat;
     private String dateFormat;
     private String dateTimeFormat;
-    private String temporalFormat;
+    private String instantFormat;
+    private String localDateFormat;
+    private String localDateTimeFormat;
+    private String localTimeFormat;
+    private String offsetDateTimeFormat;
+    private String offsetTimeFormat;
+    private String yearFormat;
+    private String yearMonthFormat;
+    private String zonedDateTimeFormat;
     private TimeZone timeZone;
     private TimeZone sqlDataAndTimeTimeZone;
     private boolean sqlDataAndTimeTimeZoneSet;
@@ -450,8 +516,32 @@ public class Configurable {
         dateTimeFormat = "";
         properties.setProperty(DATETIME_FORMAT_KEY, dateTimeFormat);
         
-        temporalFormat = "";
-        properties.setProperty(TEMPORAL_FORMAT_KEY, temporalFormat);
+        instantFormat = "";
+        properties.setProperty(INSTANT_FORMAT_KEY, instantFormat);
+
+        localDateFormat = "";
+        properties.setProperty(LOCALDATE_FORMAT_KEY, localDateFormat);
+
+        localDateTimeFormat = "";
+        properties.setProperty(LOCALDATETIME_FORMAT_KEY, localDateTimeFormat);
+
+        localTimeFormat = "";
+        properties.setProperty(LOCALTIME_FORMAT_KEY, localTimeFormat);
+
+        offsetDateTimeFormat = "";
+        properties.setProperty(OFFSETDATETIME_FORMAT_KEY, offsetDateTimeFormat);
+
+        offsetTimeFormat = "";
+        properties.setProperty(OFFSETTIME_FORMAT_KEY, offsetTimeFormat);
+
+        yearFormat = "";
+        properties.setProperty(YEAR_FORMAT_KEY, yearFormat);
+
+        yearMonthFormat = "";
+        properties.setProperty(YEARMONTH_FORMAT_KEY, yearMonthFormat);
+
+        zonedDateTimeFormat = "";
+        properties.setProperty(ZONEDDATETIME_FORMAT_KEY, zonedDateTimeFormat);
 
         classicCompatible = Integer.valueOf(0);
         properties.setProperty(CLASSIC_COMPATIBLE_KEY, classicCompatible.toString());
@@ -1277,10 +1367,67 @@ public class Configurable {
     public boolean isDateTimeFormatSet() {
         return dateTimeFormat != null;
     }
-    
-    public String getTemporalFormat() {
-        return temporalFormat != null ? temporalFormat : parent.getTemporalFormat();
+
+    public String getInstantFormat() {
+       return instantFormat == null ? parent.getInstantFormat() : instantFormat;
     }
+
+    public String getLocalDateFormat() {
+        return localDateFormat == null ? parent.getLocalDateFormat() : localDateFormat;
+    }
+
+    public String getLocalDateTimeFormat() {
+        return localDateTimeFormat == null ? parent.getLocalDateTimeFormat() : localDateTimeFormat;
+    }
+
+    public String getLocalTimeFormat() {
+        return localTimeFormat == null ? parent.getLocalTimeFormat() : localTimeFormat;
+    }
+
+    public String getOffsetDateTimeFormat() {
+        return offsetDateTimeFormat == null ? parent.getOffsetDateTimeFormat() : offsetDateTimeFormat;
+    }
+
+    public String getOffsetTimeFormat() {
+        return offsetTimeFormat == null ? parent.getOffsetTimeFormat() : offsetTimeFormat;
+    }
+
+    public String getYearFormat() {
+        return yearFormat == null ? parent.getYearFormat() : yearFormat;
+    }
+
+    public String getYearMonthFormat() {
+        return yearMonthFormat == null ? parent.getYearMonthFormat() : yearMonthFormat;
+    }
+
+    public String getZonedDateTimeFormat() {
+        return zonedDateTimeFormat == null ? parent.getZonedDateTimeFormat() : zonedDateTimeFormat;
+    }
+
+    public String getTemporalFormat(Temporal temporal) {
+        if (temporal instanceof Instant) {
+            return getInstantFormat();
+        } else if (temporal instanceof LocalDate) {
+            return getLocalDateFormat();
+        } else if (temporal instanceof LocalDateTime) {
+            return getLocalDateTimeFormat();
+        } else if (temporal instanceof LocalTime) {
+            return getLocalTimeFormat();
+        } else if (temporal instanceof OffsetDateTime) {
+            return getOffsetDateTimeFormat();
+        } else if (temporal instanceof OffsetTime) {
+            return getOffsetTimeFormat();
+        } else if (temporal instanceof Year) {
+            return getYearFormat();
+        } else if (temporal instanceof YearMonth) {
+            return getYearMonthFormat();
+        } else if (temporal instanceof ZonedDateTime) {
+            return getZonedDateTimeFormat();
+        } else {
+            return "";
+        }
+    }
+
     /**
      * Getter pair of {@link #setCustomDateFormats(Map)}; do not modify the returned {@link Map}! To be consistent with
      * other setting getters, if this setting was set directly on this {@link Configurable} object, this simply returns
@@ -2657,8 +2804,24 @@ public class Configurable {
                 setDateFormat(value);
             } else if (DATETIME_FORMAT_KEY_SNAKE_CASE.equals(name) || DATETIME_FORMAT_KEY_CAMEL_CASE.equals(name)) {
                 setDateTimeFormat(value);
-            } else if (TEMPORAL_FORMAT_KEY_SNAKE_CASE.equals(name) || TEMPORAL_FORMAT_KEY_CAMEL_CASE.equals(name)) {
-                this.temporalFormat = value;
+            } else if (INSTANT_FORMAT_KEY_SNAKE_CASE.equals(name) || INSTANT_FORMAT_KEY_CAMEL_CASE.equals(name)) {
+                this.instantFormat = value;
+            } else if (LOCALDATE_FORMAT_KEY_SNAKE_CASE.equals(name) || LOCALDATE_FORMAT_KEY_CAMEL_CASE.equals(name)) {
+                this.localDateFormat = value;
+            } else if (LOCALDATETIME_FORMAT_KEY_SNAKE_CASE.equals(name) || LOCALDATETIME_FORMAT_KEY_CAMEL_CASE.equals(name)) {
+                this.localDateTimeFormat = value;
+            } else if (LOCALTIME_FORMAT_KEY_SNAKE_CASE.equals(name) || LOCALTIME_FORMAT_KEY_CAMEL_CASE.equals(name)) {
+                this.localTimeFormat = value;
+            } else if (OFFSETDATETIME_FORMAT_KEY_SNAKE_CASE.equals(name) || OFFSETDATETIME_FORMAT_KEY_CAMEL_CASE.equals(name)) {
+                this.offsetDateTimeFormat = value;
+            } else if (OFFSETTIME_FORMAT_KEY_SNAKE_CASE.equals(name) || OFFSETTIME_FORMAT_KEY_CAMEL_CASE.equals(name)) {
+                this.offsetTimeFormat = value;
+            } else if (YEAR_FORMAT_KEY_SNAKE_CASE.equals(name) || YEAR_FORMAT_KEY_CAMEL_CASE.equals(name)) {
+                this.yearFormat = value;
+            } else if (YEARMONTH_FORMAT_KEY_SNAKE_CASE.equals(name) || YEARMONTH_FORMAT_KEY_CAMEL_CASE.equals(name)) {
+                this.yearMonthFormat = value;
+            } else if (ZONEDDATETIME_FORMAT_KEY_SNAKE_CASE.equals(name) || ZONEDDATETIME_FORMAT_KEY_CAMEL_CASE.equals(name)) {
+                this.zonedDateTimeFormat = value;
             } else if (CUSTOM_DATE_FORMATS_KEY_SNAKE_CASE.equals(name)
                     || CUSTOM_DATE_FORMATS_KEY_CAMEL_CASE.equals(name)) {
                 Map map = (Map) _ObjectBuilderSettingEvaluator.eval(

--- a/src/main/java/freemarker/core/Configurable.java
+++ b/src/main/java/freemarker/core/Configurable.java
@@ -152,37 +152,37 @@ public class Configurable {
     public static final String INSTANT_FORMAT_KEY_CAMEL_CASE = "instantFormat";
     public static final String INSTANT_FORMAT_KEY = INSTANT_FORMAT_KEY_SNAKE_CASE;
 
-    public static final String LOCALDATE_FORMAT_KEY_SNAKE_CASE = "localdate_format";
-    public static final String LOCALDATE_FORMAT_KEY_CAMEL_CASE = "localdateFormat";
-    public static final String LOCALDATE_FORMAT_KEY = LOCALDATE_FORMAT_KEY_SNAKE_CASE;
+    public static final String LOCAL_DATE_FORMAT_KEY_SNAKE_CASE = "local_date_format";
+    public static final String LOCAL_DATE_FORMAT_KEY_CAMEL_CASE = "localDateFormat";
+    public static final String LOCAL_DATE_FORMAT_KEY = LOCAL_DATE_FORMAT_KEY_SNAKE_CASE;
 
-    public static final String LOCALDATETIME_FORMAT_KEY_SNAKE_CASE = "localdatetime_format";
-    public static final String LOCALDATETIME_FORMAT_KEY_CAMEL_CASE = "localdatetimeFormat";
-    public static final String LOCALDATETIME_FORMAT_KEY = LOCALDATETIME_FORMAT_KEY_SNAKE_CASE;
+    public static final String LOCAL_DATE_TIME_FORMAT_KEY_SNAKE_CASE = "local_date_time_format";
+    public static final String LOCAL_DATE_TIME_FORMAT_KEY_CAMEL_CASE = "localDateTimeFormat";
+    public static final String LOCAL_DATE_TIME_FORMAT_KEY = LOCAL_DATE_TIME_FORMAT_KEY_SNAKE_CASE;
 
-    public static final String LOCALTIME_FORMAT_KEY_SNAKE_CASE = "localtime_format";
-    public static final String LOCALTIME_FORMAT_KEY_CAMEL_CASE = "localtimeFormat";
-    public static final String LOCALTIME_FORMAT_KEY = LOCALTIME_FORMAT_KEY_SNAKE_CASE;
+    public static final String LOCAL_TIME_FORMAT_KEY_SNAKE_CASE = "local_time_format";
+    public static final String LOCAL_TIME_FORMAT_KEY_CAMEL_CASE = "localTimeFormat";
+    public static final String LOCAL_TIME_FORMAT_KEY = LOCAL_TIME_FORMAT_KEY_SNAKE_CASE;
 
-    public static final String OFFSETDATETIME_FORMAT_KEY_SNAKE_CASE = "offsetdatetime_format";
-    public static final String OFFSETDATETIME_FORMAT_KEY_CAMEL_CASE = "offsetdatetimeFormat";
-    public static final String OFFSETDATETIME_FORMAT_KEY = OFFSETDATETIME_FORMAT_KEY_SNAKE_CASE;
+    public static final String OFFSET_DATE_TIME_FORMAT_KEY_SNAKE_CASE = "offset_date_time_format";
+    public static final String OFFSET_DATE_TIME_FORMAT_KEY_CAMEL_CASE = "offsetDateTimeFormat";
+    public static final String OFFSET_DATE_TIME_FORMAT_KEY = OFFSET_DATE_TIME_FORMAT_KEY_SNAKE_CASE;
 
-    public static final String OFFSETTIME_FORMAT_KEY_SNAKE_CASE = "offsettime_format";
-    public static final String OFFSETTIME_FORMAT_KEY_CAMEL_CASE = "offsettimeFormat";
-    public static final String OFFSETTIME_FORMAT_KEY = OFFSETTIME_FORMAT_KEY_SNAKE_CASE;
+    public static final String OFFSET_TIME_FORMAT_KEY_SNAKE_CASE = "offset_time_format";
+    public static final String OFFSET_TIME_FORMAT_KEY_CAMEL_CASE = "offsetTimeFormat";
+    public static final String OFFSET_TIME_FORMAT_KEY = OFFSET_TIME_FORMAT_KEY_SNAKE_CASE;
 
     public static final String YEAR_FORMAT_KEY_SNAKE_CASE = "year_format";
     public static final String YEAR_FORMAT_KEY_CAMEL_CASE = "yearFormat";
     public static final String YEAR_FORMAT_KEY = YEAR_FORMAT_KEY_SNAKE_CASE;
 
-    public static final String YEARMONTH_FORMAT_KEY_SNAKE_CASE = "yearmonth_format";
-    public static final String YEARMONTH_FORMAT_KEY_CAMEL_CASE = "yearmonthFormat";
-    public static final String YEARMONTH_FORMAT_KEY = YEARMONTH_FORMAT_KEY_SNAKE_CASE;
+    public static final String YEAR_MONTH_FORMAT_KEY_SNAKE_CASE = "year_month_format";
+    public static final String YEAR_MONTH_FORMAT_KEY_CAMEL_CASE = "yearMonthFormat";
+    public static final String YEAR_MONTH_FORMAT_KEY = YEAR_MONTH_FORMAT_KEY_SNAKE_CASE;
 
-    public static final String ZONEDDATETIME_FORMAT_KEY_SNAKE_CASE = "zoneddatetime_format";
-    public static final String ZONEDDATETIME_FORMAT_KEY_CAMEL_CASE = "zoneddatetimeFormat";
-    public static final String ZONEDDATETIME_FORMAT_KEY = ZONEDDATETIME_FORMAT_KEY_SNAKE_CASE;
+    public static final String ZONED_DATE_TIME_FORMAT_KEY_SNAKE_CASE = "zoned_date_time_format";
+    public static final String ZONED_DATE_TIME_FORMAT_KEY_CAMEL_CASE = "zonedDateTimeFormat";
+    public static final String ZONED_DATE_TIME_FORMAT_KEY = ZONED_DATE_TIME_FORMAT_KEY_SNAKE_CASE;
 
     /** Legacy, snake case ({@code like_this}) variation of the setting name. @since 2.3.23 */
     public static final String TIME_ZONE_KEY_SNAKE_CASE = "time_zone";
@@ -359,16 +359,16 @@ public class Configurable {
         INSTANT_FORMAT_KEY_SNAKE_CASE,
         LAZY_AUTO_IMPORTS_KEY_SNAKE_CASE,
         LAZY_IMPORTS_KEY_SNAKE_CASE,
-        LOCALDATE_FORMAT_KEY_SNAKE_CASE,
-        LOCALDATETIME_FORMAT_KEY_SNAKE_CASE,
+        LOCAL_DATE_FORMAT_KEY_SNAKE_CASE,
+        LOCAL_DATE_TIME_FORMAT_KEY_SNAKE_CASE,
+        LOCAL_TIME_FORMAT_KEY_SNAKE_CASE,
         LOCALE_KEY_SNAKE_CASE,
-        LOCALTIME_FORMAT_KEY_SNAKE_CASE,
         LOG_TEMPLATE_EXCEPTIONS_KEY_SNAKE_CASE,
         NEW_BUILTIN_CLASS_RESOLVER_KEY_SNAKE_CASE,
         NUMBER_FORMAT_KEY_SNAKE_CASE,
         OBJECT_WRAPPER_KEY_SNAKE_CASE,
-        OFFSETDATETIME_FORMAT_KEY_SNAKE_CASE,
-        OFFSETTIME_FORMAT_KEY_SNAKE_CASE,
+        OFFSET_DATE_TIME_FORMAT_KEY_SNAKE_CASE,
+        OFFSET_TIME_FORMAT_KEY_SNAKE_CASE,
         OUTPUT_ENCODING_KEY_SNAKE_CASE,
         SHOW_ERROR_TIPS_KEY_SNAKE_CASE,
         SQL_DATE_AND_TIME_TIME_ZONE_KEY_SNAKE_CASE,
@@ -380,8 +380,8 @@ public class Configurable {
         URL_ESCAPING_CHARSET_KEY_SNAKE_CASE,
         WRAP_UNCHECKED_EXCEPTIONS_KEY_SNAKE_CASE,
         YEAR_FORMAT_KEY_SNAKE_CASE,
-        YEARMONTH_FORMAT_KEY_SNAKE_CASE,
-        ZONEDDATETIME_FORMAT_KEY_SNAKE_CASE
+        YEAR_MONTH_FORMAT_KEY_SNAKE_CASE,
+        ZONED_DATE_TIME_FORMAT_KEY_SNAKE_CASE
     };
 
     private static final String[] SETTING_NAMES_CAMEL_CASE = new String[] {
@@ -401,16 +401,16 @@ public class Configurable {
         INSTANT_FORMAT_KEY_CAMEL_CASE,
         LAZY_AUTO_IMPORTS_KEY_CAMEL_CASE,
         LAZY_IMPORTS_KEY_CAMEL_CASE,
-        LOCALDATE_FORMAT_KEY_CAMEL_CASE,
-        LOCALDATETIME_FORMAT_KEY_CAMEL_CASE,
+        LOCAL_DATE_FORMAT_KEY_CAMEL_CASE,
+        LOCAL_DATE_TIME_FORMAT_KEY_CAMEL_CASE,
+        LOCAL_TIME_FORMAT_KEY_CAMEL_CASE,
         LOCALE_KEY_CAMEL_CASE,
-        LOCALTIME_FORMAT_KEY_CAMEL_CASE,
         LOG_TEMPLATE_EXCEPTIONS_KEY_CAMEL_CASE,
         NEW_BUILTIN_CLASS_RESOLVER_KEY_CAMEL_CASE,
         NUMBER_FORMAT_KEY_CAMEL_CASE,
         OBJECT_WRAPPER_KEY_CAMEL_CASE,
-        OFFSETDATETIME_FORMAT_KEY_CAMEL_CASE,
-        OFFSETTIME_FORMAT_KEY_CAMEL_CASE,
+        OFFSET_DATE_TIME_FORMAT_KEY_CAMEL_CASE,
+        OFFSET_TIME_FORMAT_KEY_CAMEL_CASE,
         OUTPUT_ENCODING_KEY_CAMEL_CASE,
         SHOW_ERROR_TIPS_KEY_CAMEL_CASE,
         SQL_DATE_AND_TIME_TIME_ZONE_KEY_CAMEL_CASE,
@@ -422,8 +422,8 @@ public class Configurable {
         URL_ESCAPING_CHARSET_KEY_CAMEL_CASE,
         WRAP_UNCHECKED_EXCEPTIONS_KEY_CAMEL_CASE,
         YEAR_FORMAT_KEY_CAMEL_CASE,
-        YEARMONTH_FORMAT_KEY_CAMEL_CASE,
-        ZONEDDATETIME_FORMAT_KEY_CAMEL_CASE
+        YEAR_MONTH_FORMAT_KEY_CAMEL_CASE,
+        ZONED_DATE_TIME_FORMAT_KEY_CAMEL_CASE
     };
 
     private Configurable parent;
@@ -520,28 +520,28 @@ public class Configurable {
         properties.setProperty(INSTANT_FORMAT_KEY, instantFormat);
 
         localDateFormat = "";
-        properties.setProperty(LOCALDATE_FORMAT_KEY, localDateFormat);
+        properties.setProperty(LOCAL_DATE_FORMAT_KEY, localDateFormat);
 
         localDateTimeFormat = "";
-        properties.setProperty(LOCALDATETIME_FORMAT_KEY, localDateTimeFormat);
+        properties.setProperty(LOCAL_DATE_TIME_FORMAT_KEY, localDateTimeFormat);
 
         localTimeFormat = "";
-        properties.setProperty(LOCALTIME_FORMAT_KEY, localTimeFormat);
+        properties.setProperty(LOCAL_TIME_FORMAT_KEY, localTimeFormat);
 
         offsetDateTimeFormat = "";
-        properties.setProperty(OFFSETDATETIME_FORMAT_KEY, offsetDateTimeFormat);
+        properties.setProperty(OFFSET_DATE_TIME_FORMAT_KEY, offsetDateTimeFormat);
 
         offsetTimeFormat = "";
-        properties.setProperty(OFFSETTIME_FORMAT_KEY, offsetTimeFormat);
+        properties.setProperty(OFFSET_TIME_FORMAT_KEY, offsetTimeFormat);
 
         yearFormat = "";
         properties.setProperty(YEAR_FORMAT_KEY, yearFormat);
 
         yearMonthFormat = "";
-        properties.setProperty(YEARMONTH_FORMAT_KEY, yearMonthFormat);
+        properties.setProperty(YEAR_MONTH_FORMAT_KEY, yearMonthFormat);
 
         zonedDateTimeFormat = "";
-        properties.setProperty(ZONEDDATETIME_FORMAT_KEY, zonedDateTimeFormat);
+        properties.setProperty(ZONED_DATE_TIME_FORMAT_KEY, zonedDateTimeFormat);
 
         classicCompatible = Integer.valueOf(0);
         properties.setProperty(CLASSIC_COMPATIBLE_KEY, classicCompatible.toString());
@@ -2806,21 +2806,21 @@ public class Configurable {
                 setDateTimeFormat(value);
             } else if (INSTANT_FORMAT_KEY_SNAKE_CASE.equals(name) || INSTANT_FORMAT_KEY_CAMEL_CASE.equals(name)) {
                 this.instantFormat = value;
-            } else if (LOCALDATE_FORMAT_KEY_SNAKE_CASE.equals(name) || LOCALDATE_FORMAT_KEY_CAMEL_CASE.equals(name)) {
+            } else if (LOCAL_DATE_FORMAT_KEY_SNAKE_CASE.equals(name) || LOCAL_DATE_FORMAT_KEY_CAMEL_CASE.equals(name)) {
                 this.localDateFormat = value;
-            } else if (LOCALDATETIME_FORMAT_KEY_SNAKE_CASE.equals(name) || LOCALDATETIME_FORMAT_KEY_CAMEL_CASE.equals(name)) {
+            } else if (LOCAL_DATE_TIME_FORMAT_KEY_SNAKE_CASE.equals(name) || LOCAL_DATE_TIME_FORMAT_KEY_CAMEL_CASE.equals(name)) {
                 this.localDateTimeFormat = value;
-            } else if (LOCALTIME_FORMAT_KEY_SNAKE_CASE.equals(name) || LOCALTIME_FORMAT_KEY_CAMEL_CASE.equals(name)) {
+            } else if (LOCAL_TIME_FORMAT_KEY_SNAKE_CASE.equals(name) || LOCAL_TIME_FORMAT_KEY_CAMEL_CASE.equals(name)) {
                 this.localTimeFormat = value;
-            } else if (OFFSETDATETIME_FORMAT_KEY_SNAKE_CASE.equals(name) || OFFSETDATETIME_FORMAT_KEY_CAMEL_CASE.equals(name)) {
+            } else if (OFFSET_DATE_TIME_FORMAT_KEY_SNAKE_CASE.equals(name) || OFFSET_DATE_TIME_FORMAT_KEY_CAMEL_CASE.equals(name)) {
                 this.offsetDateTimeFormat = value;
-            } else if (OFFSETTIME_FORMAT_KEY_SNAKE_CASE.equals(name) || OFFSETTIME_FORMAT_KEY_CAMEL_CASE.equals(name)) {
+            } else if (OFFSET_TIME_FORMAT_KEY_SNAKE_CASE.equals(name) || OFFSET_TIME_FORMAT_KEY_CAMEL_CASE.equals(name)) {
                 this.offsetTimeFormat = value;
             } else if (YEAR_FORMAT_KEY_SNAKE_CASE.equals(name) || YEAR_FORMAT_KEY_CAMEL_CASE.equals(name)) {
                 this.yearFormat = value;
-            } else if (YEARMONTH_FORMAT_KEY_SNAKE_CASE.equals(name) || YEARMONTH_FORMAT_KEY_CAMEL_CASE.equals(name)) {
+            } else if (YEAR_MONTH_FORMAT_KEY_SNAKE_CASE.equals(name) || YEAR_MONTH_FORMAT_KEY_CAMEL_CASE.equals(name)) {
                 this.yearMonthFormat = value;
-            } else if (ZONEDDATETIME_FORMAT_KEY_SNAKE_CASE.equals(name) || ZONEDDATETIME_FORMAT_KEY_CAMEL_CASE.equals(name)) {
+            } else if (ZONED_DATE_TIME_FORMAT_KEY_SNAKE_CASE.equals(name) || ZONED_DATE_TIME_FORMAT_KEY_CAMEL_CASE.equals(name)) {
                 this.zonedDateTimeFormat = value;
             } else if (CUSTOM_DATE_FORMATS_KEY_SNAKE_CASE.equals(name)
                     || CUSTOM_DATE_FORMATS_KEY_CAMEL_CASE.equals(name)) {

--- a/src/main/java/freemarker/core/Configurable.java
+++ b/src/main/java/freemarker/core/Configurable.java
@@ -137,7 +137,11 @@ public class Configurable {
     public static final String DATETIME_FORMAT_KEY_CAMEL_CASE = "datetimeFormat";
     /** Alias to the {@code ..._SNAKE_CASE} variation due to backward compatibility constraints. */
     public static final String DATETIME_FORMAT_KEY = DATETIME_FORMAT_KEY_SNAKE_CASE;
-    
+
+    public static final String TEMPORAL_FORMAT_KEY_SNAKE_CASE = "temporal_format";
+    public static final String TEMPORAL_FORMAT_KEY_CAMEL_CASE = "temporalFormat";
+    public static final String TEMPORAL_FORMAT_KEY = TEMPORAL_FORMAT_KEY_SNAKE_CASE;
+
     /** Legacy, snake case ({@code like_this}) variation of the setting name. @since 2.3.23 */
     public static final String TIME_ZONE_KEY_SNAKE_CASE = "time_zone";
     /** Modern, camel case ({@code likeThis}) variation of the setting name. @since 2.3.23 */
@@ -322,6 +326,7 @@ public class Configurable {
         SQL_DATE_AND_TIME_TIME_ZONE_KEY_SNAKE_CASE,
         STRICT_BEAN_MODELS_KEY,
         TEMPLATE_EXCEPTION_HANDLER_KEY_SNAKE_CASE,
+        TEMPORAL_FORMAT_KEY_SNAKE_CASE,
         TIME_FORMAT_KEY_SNAKE_CASE,
         TIME_ZONE_KEY_SNAKE_CASE,
         TRUNCATE_BUILTIN_ALGORITHM_KEY_SNAKE_CASE,
@@ -355,6 +360,7 @@ public class Configurable {
         SQL_DATE_AND_TIME_TIME_ZONE_KEY_CAMEL_CASE,
         STRICT_BEAN_MODELS_KEY_CAMEL_CASE,
         TEMPLATE_EXCEPTION_HANDLER_KEY_CAMEL_CASE,
+        TEMPORAL_FORMAT_KEY_CAMEL_CASE,
         TIME_FORMAT_KEY_CAMEL_CASE,
         TIME_ZONE_KEY_CAMEL_CASE,
         TRUNCATE_BUILTIN_ALGORITHM_KEY_CAMEL_CASE,
@@ -371,6 +377,7 @@ public class Configurable {
     private String timeFormat;
     private String dateFormat;
     private String dateTimeFormat;
+    private String temporalFormat;
     private TimeZone timeZone;
     private TimeZone sqlDataAndTimeTimeZone;
     private boolean sqlDataAndTimeTimeZoneSet;
@@ -443,6 +450,9 @@ public class Configurable {
         dateTimeFormat = "";
         properties.setProperty(DATETIME_FORMAT_KEY, dateTimeFormat);
         
+        temporalFormat = "";
+        properties.setProperty(TEMPORAL_FORMAT_KEY, temporalFormat);
+
         classicCompatible = Integer.valueOf(0);
         properties.setProperty(CLASSIC_COMPATIBLE_KEY, classicCompatible.toString());
         
@@ -1268,6 +1278,9 @@ public class Configurable {
         return dateTimeFormat != null;
     }
     
+    public String getTemporalFormat() {
+        return temporalFormat != null ? temporalFormat : parent.getTemporalFormat();
+    }
     /**
      * Getter pair of {@link #setCustomDateFormats(Map)}; do not modify the returned {@link Map}! To be consistent with
      * other setting getters, if this setting was set directly on this {@link Configurable} object, this simply returns
@@ -2644,6 +2657,8 @@ public class Configurable {
                 setDateFormat(value);
             } else if (DATETIME_FORMAT_KEY_SNAKE_CASE.equals(name) || DATETIME_FORMAT_KEY_CAMEL_CASE.equals(name)) {
                 setDateTimeFormat(value);
+            } else if (TEMPORAL_FORMAT_KEY_SNAKE_CASE.equals(name) || TEMPORAL_FORMAT_KEY_CAMEL_CASE.equals(name)) {
+                this.temporalFormat = value;
             } else if (CUSTOM_DATE_FORMATS_KEY_SNAKE_CASE.equals(name)
                     || CUSTOM_DATE_FORMATS_KEY_CAMEL_CASE.equals(name)) {
                 Map map = (Map) _ObjectBuilderSettingEvaluator.eval(

--- a/src/main/java/freemarker/core/Environment.java
+++ b/src/main/java/freemarker/core/Environment.java
@@ -1780,7 +1780,7 @@ public final class Environment extends Configurable {
     }
 
     String formatTemporalToPlainText(TemplateTemporalModel ttm, Expression tdmSourceExpr) throws TemplateException {
-        TemplateTemporalFormat ttf = getTemplateTemporalFormat(configuration.getTemporalFormat(ttm.getAsTemporal()));
+        TemplateTemporalFormat ttf = getTemplateTemporalFormat(configuration.getTemporalFormat(ttm.getAsTemporal().getClass()));
         try {
             return EvalUtil.assertFormatResultNotNull(ttf.format(ttm));
         } catch (TemplateValueFormatException e) {
@@ -2220,7 +2220,7 @@ public final class Environment extends Configurable {
     }
 
     TemplateTemporalFormat getTemplateTemporalFormat(Temporal temporal) {
-        return new TemplateTemporalFormat(getTemporalFormat(temporal), getLocale(), getTimeZone());
+        return new TemplateTemporalFormat(getTemporalFormat(temporal.getClass()), getLocale(), getTimeZone());
     }
 
     private TemplateTemporalFormat getTemplateTemporalFormat(String format) {

--- a/src/main/java/freemarker/core/Environment.java
+++ b/src/main/java/freemarker/core/Environment.java
@@ -29,6 +29,7 @@ import java.text.Collator;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.text.NumberFormat;
+import java.time.temporal.Temporal;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -70,6 +71,7 @@ import freemarker.template.TemplateNodeModel;
 import freemarker.template.TemplateNumberModel;
 import freemarker.template.TemplateScalarModel;
 import freemarker.template.TemplateSequenceModel;
+import freemarker.template.TemplateTemporalModel;
 import freemarker.template.TemplateTransformModel;
 import freemarker.template.TransformControl;
 import freemarker.template._TemplateAPI;
@@ -1765,6 +1767,28 @@ public final class Environment extends Configurable {
     }
 
     /**
+     * @param blamedDateSourceExp
+     *            The blamed expression if an error occurs; only used for error messages.
+     */
+    String formatTemporalToPlainText(TemplateTemporalModel ttm, String formatString, Expression blamedDateSourceExp) throws TemplateException, TemplateValueFormatException {
+        TemplateTemporalFormat ttf = getTemplateTemporalFormat(formatString);
+        try {
+            return EvalUtil.assertFormatResultNotNull(ttf.format(ttm));
+        } catch (TemplateValueFormatException e) {
+            throw _MessageUtil.newCantFormatDateException(ttf, blamedDateSourceExp, e, true);
+        }
+    }
+
+    String formatTemporalToPlainText(TemplateTemporalModel ttm, Expression tdmSourceExpr) throws TemplateException {
+        TemplateTemporalFormat ttf = getTemplateTemporalFormat(configuration.getTemporalFormat());
+        try {
+            return EvalUtil.assertFormatResultNotNull(ttf.format(ttm));
+        } catch (TemplateValueFormatException e) {
+            throw _MessageUtil.newCantFormatDateException(ttf, tdmSourceExpr, e, false);
+        }
+    }
+
+    /**
      * Gets a {@link TemplateDateFormat} using the date/time/datetime format settings and the current locale and time
      * zone. (The current locale is the locale returned by {@link #getLocale()}. The current time zone is
      * {@link #getTimeZone()} or {@link #getSQLDateAndTimeTimeZone()}).
@@ -2193,6 +2217,14 @@ public final class Environment extends Configurable {
         return dateType
                 + (zonelessInput ? CACHED_TDFS_ZONELESS_INPUT_OFFS : 0)
                 + (sqlDTTZ ? CACHED_TDFS_SQL_D_T_TZ_OFFS : 0);
+    }
+
+    TemplateTemporalFormat getTemplateTemporalFormat() {
+        return new TemplateTemporalFormat(getTemporalFormat(), getLocale(), getTimeZone());
+    }
+
+    private TemplateTemporalFormat getTemplateTemporalFormat(String format) {
+        return new TemplateTemporalFormat(format, getLocale(), getTimeZone());
     }
 
     /**

--- a/src/main/java/freemarker/core/Environment.java
+++ b/src/main/java/freemarker/core/Environment.java
@@ -1780,7 +1780,7 @@ public final class Environment extends Configurable {
     }
 
     String formatTemporalToPlainText(TemplateTemporalModel ttm, Expression tdmSourceExpr) throws TemplateException {
-        TemplateTemporalFormat ttf = getTemplateTemporalFormat(configuration.getTemporalFormat());
+        TemplateTemporalFormat ttf = getTemplateTemporalFormat(configuration.getTemporalFormat(ttm.getAsTemporal()));
         try {
             return EvalUtil.assertFormatResultNotNull(ttf.format(ttm));
         } catch (TemplateValueFormatException e) {
@@ -2219,8 +2219,8 @@ public final class Environment extends Configurable {
                 + (sqlDTTZ ? CACHED_TDFS_SQL_D_T_TZ_OFFS : 0);
     }
 
-    TemplateTemporalFormat getTemplateTemporalFormat() {
-        return new TemplateTemporalFormat(getTemporalFormat(), getLocale(), getTimeZone());
+    TemplateTemporalFormat getTemplateTemporalFormat(Temporal temporal) {
+        return new TemplateTemporalFormat(getTemporalFormat(temporal), getLocale(), getTimeZone());
     }
 
     private TemplateTemporalFormat getTemplateTemporalFormat(String format) {

--- a/src/main/java/freemarker/core/EvalUtil.java
+++ b/src/main/java/freemarker/core/EvalUtil.java
@@ -409,7 +409,7 @@ class EvalUtil {
             }
         } else if (tm instanceof TemplateTemporalModel) {
             TemplateTemporalModel ttm = (TemplateTemporalModel) tm;
-            TemplateTemporalFormat format = env.getTemplateTemporalFormat();
+            TemplateTemporalFormat format = env.getTemplateTemporalFormat(ttm.getAsTemporal());
             try {
                 return assertFormatResultNotNull(format.format(ttm));
             } catch (TemplateValueFormatException e) {
@@ -452,7 +452,7 @@ class EvalUtil {
             }
         } else if (tm instanceof TemplateTemporalModel) {
             TemplateTemporalModel ttm = (TemplateTemporalModel) tm;
-            TemplateTemporalFormat format = env.getTemplateTemporalFormat();
+            TemplateTemporalFormat format = env.getTemplateTemporalFormat(ttm.getAsTemporal());
             try {
                 return ensureFormatResultString(format.format(ttm), exp, env);
             } catch (TemplateValueFormatException e) {

--- a/src/main/java/freemarker/core/Expression.java
+++ b/src/main/java/freemarker/core/Expression.java
@@ -32,6 +32,7 @@ import freemarker.template.TemplateModelException;
 import freemarker.template.TemplateNumberModel;
 import freemarker.template.TemplateScalarModel;
 import freemarker.template.TemplateSequenceModel;
+import freemarker.template.TemplateTemporalModel;
 import freemarker.template.utility.UndeclaredThrowableException;
 
 /**
@@ -238,6 +239,7 @@ abstract public class Expression extends TemplateObject {
             return ((TemplateHashModel) model).isEmpty();
         } else if (model instanceof TemplateNumberModel
                 || model instanceof TemplateDateModel
+                || model instanceof TemplateTemporalModel
                 || model instanceof TemplateBooleanModel) {
             return false;
         } else {

--- a/src/main/java/freemarker/core/PropertySetting.java
+++ b/src/main/java/freemarker/core/PropertySetting.java
@@ -56,6 +56,7 @@ final class PropertySetting extends TemplateElement {
             Configurable.OUTPUT_ENCODING_KEY_SNAKE_CASE,
             Configurable.SQL_DATE_AND_TIME_TIME_ZONE_KEY_CAMEL_CASE,
             Configurable.SQL_DATE_AND_TIME_TIME_ZONE_KEY,
+            Configurable.TEMPORAL_FORMAT_KEY_CAMEL_CASE,
             Configurable.TIME_FORMAT_KEY_CAMEL_CASE,
             Configurable.TIME_ZONE_KEY_CAMEL_CASE,
             Configurable.TIME_FORMAT_KEY_SNAKE_CASE,

--- a/src/main/java/freemarker/core/PropertySetting.java
+++ b/src/main/java/freemarker/core/PropertySetting.java
@@ -49,21 +49,39 @@ final class PropertySetting extends TemplateElement {
             Configurable.DATE_FORMAT_KEY_SNAKE_CASE,
             Configurable.DATETIME_FORMAT_KEY_CAMEL_CASE,
             Configurable.DATETIME_FORMAT_KEY_SNAKE_CASE,
+            Configurable.INSTANT_FORMAT_KEY_CAMEL_CASE,
+            Configurable.INSTANT_FORMAT_KEY_SNAKE_CASE,
+            Configurable.LOCALDATE_FORMAT_KEY_CAMEL_CASE,
+            Configurable.LOCALDATE_FORMAT_KEY_SNAKE_CASE,
+            Configurable.LOCALDATETIME_FORMAT_KEY_CAMEL_CASE,
+            Configurable.LOCALDATETIME_FORMAT_KEY_SNAKE_CASE,
             Configurable.LOCALE_KEY,
+            Configurable.LOCALTIME_FORMAT_KEY_CAMEL_CASE,
+            Configurable.LOCALTIME_FORMAT_KEY_SNAKE_CASE,
             Configurable.NUMBER_FORMAT_KEY_CAMEL_CASE,
             Configurable.NUMBER_FORMAT_KEY_SNAKE_CASE,
+            Configurable.OFFSETDATETIME_FORMAT_KEY_CAMEL_CASE,
+            Configurable.OFFSETDATETIME_FORMAT_KEY_SNAKE_CASE,
+            Configurable.OFFSETTIME_FORMAT_KEY_CAMEL_CASE,
+            Configurable.OFFSETTIME_FORMAT_KEY_SNAKE_CASE,
             Configurable.OUTPUT_ENCODING_KEY_CAMEL_CASE,
             Configurable.OUTPUT_ENCODING_KEY_SNAKE_CASE,
             Configurable.SQL_DATE_AND_TIME_TIME_ZONE_KEY_CAMEL_CASE,
             Configurable.SQL_DATE_AND_TIME_TIME_ZONE_KEY,
-            Configurable.TEMPORAL_FORMAT_KEY_CAMEL_CASE,
             Configurable.TIME_FORMAT_KEY_CAMEL_CASE,
             Configurable.TIME_ZONE_KEY_CAMEL_CASE,
             Configurable.TIME_FORMAT_KEY_SNAKE_CASE,
             Configurable.TIME_ZONE_KEY_SNAKE_CASE,
             Configurable.URL_ESCAPING_CHARSET_KEY_CAMEL_CASE,
-            Configurable.URL_ESCAPING_CHARSET_KEY_SNAKE_CASE
+            Configurable.URL_ESCAPING_CHARSET_KEY_SNAKE_CASE,
+            Configurable.YEAR_FORMAT_KEY_CAMEL_CASE,
+            Configurable.YEAR_FORMAT_KEY_SNAKE_CASE,
+            Configurable.YEARMONTH_FORMAT_KEY_CAMEL_CASE,
+            Configurable.YEARMONTH_FORMAT_KEY_SNAKE_CASE,
+            Configurable.ZONEDDATETIME_FORMAT_KEY_CAMEL_CASE,
+            Configurable.ZONEDDATETIME_FORMAT_KEY_SNAKE_CASE
     };
+
 
     PropertySetting(Token keyTk, FMParserTokenManager tokenManager, Expression value, Configuration cfg)
             throws ParseException {

--- a/src/main/java/freemarker/core/PropertySetting.java
+++ b/src/main/java/freemarker/core/PropertySetting.java
@@ -51,19 +51,19 @@ final class PropertySetting extends TemplateElement {
             Configurable.DATETIME_FORMAT_KEY_SNAKE_CASE,
             Configurable.INSTANT_FORMAT_KEY_CAMEL_CASE,
             Configurable.INSTANT_FORMAT_KEY_SNAKE_CASE,
-            Configurable.LOCALDATE_FORMAT_KEY_CAMEL_CASE,
-            Configurable.LOCALDATE_FORMAT_KEY_SNAKE_CASE,
-            Configurable.LOCALDATETIME_FORMAT_KEY_CAMEL_CASE,
-            Configurable.LOCALDATETIME_FORMAT_KEY_SNAKE_CASE,
+            Configurable.LOCAL_DATE_FORMAT_KEY_CAMEL_CASE,
+            Configurable.LOCAL_DATE_TIME_FORMAT_KEY_CAMEL_CASE,
+            Configurable.LOCAL_TIME_FORMAT_KEY_CAMEL_CASE,
+            Configurable.LOCAL_DATE_FORMAT_KEY_SNAKE_CASE,
+            Configurable.LOCAL_DATE_TIME_FORMAT_KEY_SNAKE_CASE,
+            Configurable.LOCAL_TIME_FORMAT_KEY_SNAKE_CASE,
             Configurable.LOCALE_KEY,
-            Configurable.LOCALTIME_FORMAT_KEY_CAMEL_CASE,
-            Configurable.LOCALTIME_FORMAT_KEY_SNAKE_CASE,
             Configurable.NUMBER_FORMAT_KEY_CAMEL_CASE,
             Configurable.NUMBER_FORMAT_KEY_SNAKE_CASE,
-            Configurable.OFFSETDATETIME_FORMAT_KEY_CAMEL_CASE,
-            Configurable.OFFSETDATETIME_FORMAT_KEY_SNAKE_CASE,
-            Configurable.OFFSETTIME_FORMAT_KEY_CAMEL_CASE,
-            Configurable.OFFSETTIME_FORMAT_KEY_SNAKE_CASE,
+            Configurable.OFFSET_DATE_TIME_FORMAT_KEY_CAMEL_CASE,
+            Configurable.OFFSET_TIME_FORMAT_KEY_CAMEL_CASE,
+            Configurable.OFFSET_DATE_TIME_FORMAT_KEY_SNAKE_CASE,
+            Configurable.OFFSET_TIME_FORMAT_KEY_SNAKE_CASE,
             Configurable.OUTPUT_ENCODING_KEY_CAMEL_CASE,
             Configurable.OUTPUT_ENCODING_KEY_SNAKE_CASE,
             Configurable.SQL_DATE_AND_TIME_TIME_ZONE_KEY_CAMEL_CASE,
@@ -75,11 +75,11 @@ final class PropertySetting extends TemplateElement {
             Configurable.URL_ESCAPING_CHARSET_KEY_CAMEL_CASE,
             Configurable.URL_ESCAPING_CHARSET_KEY_SNAKE_CASE,
             Configurable.YEAR_FORMAT_KEY_CAMEL_CASE,
+            Configurable.YEAR_MONTH_FORMAT_KEY_CAMEL_CASE,
             Configurable.YEAR_FORMAT_KEY_SNAKE_CASE,
-            Configurable.YEARMONTH_FORMAT_KEY_CAMEL_CASE,
-            Configurable.YEARMONTH_FORMAT_KEY_SNAKE_CASE,
-            Configurable.ZONEDDATETIME_FORMAT_KEY_CAMEL_CASE,
-            Configurable.ZONEDDATETIME_FORMAT_KEY_SNAKE_CASE
+            Configurable.YEAR_MONTH_FORMAT_KEY_SNAKE_CASE,
+            Configurable.ZONED_DATE_TIME_FORMAT_KEY_CAMEL_CASE,
+            Configurable.ZONED_DATE_TIME_FORMAT_KEY_SNAKE_CASE
     };
 
 
@@ -90,7 +90,7 @@ final class PropertySetting extends TemplateElement {
             StringBuilder sb = new StringBuilder();
             if (_TemplateAPI.getConfigurationSettingNames(cfg, true).contains(key)
                     || _TemplateAPI.getConfigurationSettingNames(cfg, false).contains(key)) {
-                sb.append("The setting name is recognized, but changing this setting from inside a template isn't "
+                sb.append("The setting name '" + key + "' is recognized, but changing this setting from inside a template isn't "
                         + "supported.");                
             } else {
                 sb.append("Unknown setting name: ");

--- a/src/main/java/freemarker/core/TemplateFormatUtil.java
+++ b/src/main/java/freemarker/core/TemplateFormatUtil.java
@@ -18,12 +18,14 @@
  */
 package freemarker.core;
 
+import java.time.temporal.Temporal;
 import java.util.Date;
 
 import freemarker.template.ObjectWrapper;
 import freemarker.template.TemplateDateModel;
 import freemarker.template.TemplateModelException;
 import freemarker.template.TemplateNumberModel;
+import freemarker.template.TemplateTemporalModel;
 
 /**
  * Utility classes for implementing {@link TemplateValueFormat}-s.
@@ -69,6 +71,14 @@ public final class TemplateFormatUtil {
         Date date = dateModel.getAsDate();
         if (date == null) {
             throw EvalUtil.newModelHasStoredNullException(Date.class, dateModel, null);
+        }
+        return date;
+    }
+
+    public static Temporal getNonNullTemporal(TemplateTemporalModel temporalModel) throws TemplateModelException {
+        Temporal date = temporalModel.getAsTemporal();
+        if (date == null) {
+            throw EvalUtil.newModelHasStoredNullException(Date.class, temporalModel, null);
         }
         return date;
     }

--- a/src/main/java/freemarker/core/TemplateTemporalFormat.java
+++ b/src/main/java/freemarker/core/TemplateTemporalFormat.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package freemarker.core;
+
+import java.util.Locale;
+import java.util.TimeZone;
+
+import freemarker.template.TemplateModelException;
+import freemarker.template.TemplateTemporalModel;
+import freemarker.template.utility.TemporalUtil;
+
+public class TemplateTemporalFormat extends TemplateValueFormat {
+    private final String format;
+    private final Locale locale;
+    private final TimeZone timeZone;
+
+    public TemplateTemporalFormat(String format, Locale locale, TimeZone timeZone) {
+        this.format = format;
+        this.locale = locale;
+        this.timeZone = timeZone;
+    }
+
+    public String format(TemplateTemporalModel temporalModel) throws TemplateValueFormatException, TemplateModelException {
+        return TemporalUtil.format(temporalModel.getAsTemporal(), format, locale, timeZone);
+    }
+
+    @Override
+    public String getDescription() {
+        return format + " " + locale.toString();
+    }
+
+    /**
+     * Tells if this formatter should be re-created if the locale changes.
+     */
+    public boolean isLocaleBound() {
+        return true;
+    }
+
+    /**
+     * Tells if this formatter should be re-created if the time zone changes. Currently always {@code true}.
+     */
+    public boolean isTimeZoneBound() {
+        return true;
+    }
+
+}

--- a/src/main/java/freemarker/core/_MessageUtil.java
+++ b/src/main/java/freemarker/core/_MessageUtil.java
@@ -322,6 +322,17 @@ public class _MessageUtil {
                 : new _MiscTemplateException(e, null, desc);
     }
     
+    public static TemplateException newCantFormatDateException(TemplateTemporalFormat format, Expression dataSrcExp,
+            TemplateValueFormatException e, boolean useTempModelExc) {
+        _ErrorDescriptionBuilder desc = new _ErrorDescriptionBuilder(
+                "Failed to format date/time/datetime with format ", new _DelayedJQuote(format.getDescription()), ": ",
+                e.getMessage())
+                .blame(dataSrcExp);
+        return useTempModelExc
+                ? new _TemplateModelException(e, null, desc)
+                : new _MiscTemplateException(e, null, desc);
+    }
+
     public static TemplateException newCantFormatNumberException(TemplateNumberFormat format, Expression dataSrcExp,
             TemplateValueFormatException e, boolean useTempModelExc) {
         _ErrorDescriptionBuilder desc = new _ErrorDescriptionBuilder(

--- a/src/main/java/freemarker/ext/beans/BeansWrapper.java
+++ b/src/main/java/freemarker/ext/beans/BeansWrapper.java
@@ -29,6 +29,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.time.temporal.Temporal;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
@@ -65,6 +66,7 @@ import freemarker.template.TemplateModelException;
 import freemarker.template.TemplateNumberModel;
 import freemarker.template.TemplateScalarModel;
 import freemarker.template.TemplateSequenceModel;
+import freemarker.template.TemplateTemporalModel;
 import freemarker.template.Version;
 import freemarker.template._TemplateAPI;
 import freemarker.template.utility.ClassUtil;
@@ -1233,6 +1235,13 @@ public class BeansWrapper implements RichObjectWrapper, WriteProtectable {
                     return date;
                 }
             }
+
+            if (Temporal.class.isAssignableFrom(targetClass) && model instanceof TemplateTemporalModel) {
+                Temporal temporal = ((TemplateTemporalModel) model).getAsTemporal();
+                if (targetClass.isInstance(temporal)) {
+                    return temporal;
+                }
+            }
         }  //  End: if (targetClass != Object.class)
         
         // Since the targetClass was of no help initially, now we use
@@ -1255,6 +1264,13 @@ public class BeansWrapper implements RichObjectWrapper, WriteProtectable {
                 Date date = ((TemplateDateModel) model).getAsDate();
                 if (itf != 0 || targetClass.isInstance(date)) {
                     return date;
+                }
+            }
+            if ((itf == 0 || (itf & TypeFlags.ACCEPTS_DATE) != 0)
+                    && model instanceof TemplateTemporalModel) {
+                Temporal temporal = ((TemplateTemporalModel) model).getAsTemporal();
+                if (itf != 0 || targetClass.isInstance(temporal)) {
+                    return temporal;
                 }
             }
             if ((itf == 0 || (itf & (TypeFlags.ACCEPTS_STRING | TypeFlags.CHARACTER)) != 0)

--- a/src/main/java/freemarker/template/DefaultObjectWrapper.java
+++ b/src/main/java/freemarker/template/DefaultObjectWrapper.java
@@ -20,15 +20,6 @@
 package freemarker.template;
 
 import java.lang.reflect.Array;
-import java.time.Instant;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.time.OffsetDateTime;
-import java.time.OffsetTime;
-import java.time.Year;
-import java.time.YearMonth;
-import java.time.ZonedDateTime;
 import java.time.temporal.Temporal;
 import java.util.ArrayList;
 import java.util.Collection;

--- a/src/main/java/freemarker/template/DefaultObjectWrapper.java
+++ b/src/main/java/freemarker/template/DefaultObjectWrapper.java
@@ -20,6 +20,16 @@
 package freemarker.template;
 
 import java.lang.reflect.Array;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.time.Year;
+import java.time.YearMonth;
+import java.time.ZonedDateTime;
+import java.time.temporal.Temporal;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Enumeration;
@@ -205,6 +215,9 @@ public class DefaultObjectWrapper extends freemarker.ext.beans.BeansWrapper {
                 return new SimpleDate((java.sql.Timestamp) obj);
             }
             return new SimpleDate((java.util.Date) obj, getDefaultDateType());
+        }
+        if (obj instanceof Temporal) {
+            return new SimpleTemporal((Temporal) obj);
         }
         final Class<?> objClass = obj.getClass();
         if (objClass.isArray()) {

--- a/src/main/java/freemarker/template/SimpleTemporal.java
+++ b/src/main/java/freemarker/template/SimpleTemporal.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package freemarker.template;
+
+import java.time.temporal.Temporal;
+
+/**
+ * A simple implementation of the <tt>TemplateDateModel</tt>
+ * interface. Note that this class is immutable.
+ * <p>This class is thread-safe.
+ */
+public class SimpleTemporal implements TemplateTemporalModel {
+	private final Temporal temporal;
+
+	/**
+	 * Creates a new date model wrapping the specified date object and
+	 * having the specified type.
+	 */
+	public SimpleTemporal(Temporal temporal) {
+		if (temporal == null) {
+			throw new IllegalArgumentException("temporal == null");
+		}
+		this.temporal = temporal;
+	}
+
+	@Override
+	public Temporal getAsTemporal() {
+		return temporal;
+	}
+
+	public String toString() {
+		return temporal.toString();
+	}
+}

--- a/src/main/java/freemarker/template/TemplateTemporalModel.java
+++ b/src/main/java/freemarker/template/TemplateTemporalModel.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package freemarker.template;
+
+import java.time.temporal.Temporal;
+
+public interface TemplateTemporalModel extends TemplateModel {
+	/**
+	 * Returns the date value. The return value must not be {@code null}.
+	 */
+	Temporal getAsTemporal() throws TemplateModelException;
+}

--- a/src/main/java/freemarker/template/utility/TemporalUtil.java
+++ b/src/main/java/freemarker/template/utility/TemporalUtil.java
@@ -1,0 +1,191 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package freemarker.template.utility;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.Year;
+import java.time.YearMonth;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.chrono.IsoChronology;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.FormatStyle;
+import java.time.temporal.ChronoField;
+import java.time.temporal.Temporal;
+import java.util.Locale;
+import java.util.TimeZone;
+import java.util.regex.Pattern;
+
+public class TemporalUtil {
+	private static final Pattern FORMAT_STYLE_PATTERN = Pattern.compile("^(short|medium|long|full)(_(short|medium|long|full))?$");
+	private final static DateTimeFormatter SHORT_FORMAT = DateTimeFormatter.ofLocalizedDateTime(FormatStyle.SHORT);
+	private final static DateTimeFormatter MEDIUM_FORMAT = DateTimeFormatter.ofLocalizedDateTime(FormatStyle.MEDIUM);
+	private final static DateTimeFormatter LONG_FORMAT = DateTimeFormatter.ofLocalizedDateTime(FormatStyle.LONG);
+	private final static DateTimeFormatter FULL_FORMAT = DateTimeFormatter.ofLocalizedDateTime(FormatStyle.FULL);
+
+	private final static DateTimeFormatter XSD_FORMAT = new DateTimeFormatterBuilder()
+			.append(DateTimeFormatter.ISO_LOCAL_DATE)
+			.optionalStart()
+			.appendLiteral('T')
+			.appendValue(ChronoField.HOUR_OF_DAY, 2)
+			.appendLiteral(":")
+			.appendValue(ChronoField.MINUTE_OF_HOUR, 2)
+			.appendLiteral(":")
+			.appendValue(ChronoField.SECOND_OF_MINUTE, 2)
+			.appendFraction(ChronoField.MILLI_OF_SECOND, 0, 3, true)
+			.optionalEnd()
+				.optionalStart()
+			.appendOffsetId()
+			.optionalEnd()
+			.toFormatter();
+	private final static DateTimeFormatter XSD_TIME_FORMAT = new DateTimeFormatterBuilder()
+			.appendValue(ChronoField.HOUR_OF_DAY, 2)
+			.appendLiteral(":")
+			.appendValue(ChronoField.MINUTE_OF_HOUR, 2)
+			.appendLiteral(":")
+			.appendValue(ChronoField.SECOND_OF_MINUTE, 2)
+			.appendFraction(ChronoField.MILLI_OF_SECOND, 0, 3, true)
+			.optionalStart()
+				.appendOffsetId()
+			.optionalEnd()
+			.toFormatter();
+	public static final DateTimeFormatter XSD_YEARMONTH_FORMAT = new DateTimeFormatterBuilder()
+			.appendValue(ChronoField.YEAR)
+			.appendLiteral("-")
+			.appendValue(ChronoField.MONTH_OF_YEAR, 2)
+			.optionalStart()
+				.appendOffsetId()
+			.optionalEnd()
+			.toFormatter();
+
+	public static final DateTimeFormatter ISO8601_FORMAT = new DateTimeFormatterBuilder()
+			.append(DateTimeFormatter.ISO_LOCAL_DATE)
+			.optionalStart()
+				.appendLiteral('T')
+				.appendValue(ChronoField.HOUR_OF_DAY, 2)
+				.appendLiteral(":")
+				.appendValue(ChronoField.MINUTE_OF_HOUR, 2)
+				.appendLiteral(":")
+				.appendValue(ChronoField.SECOND_OF_MINUTE, 2)
+				.appendFraction(ChronoField.MILLI_OF_SECOND, 0, 3, true)
+				.optionalStart()
+					.appendOffsetId()
+				.optionalEnd()
+			.optionalEnd()
+			.toFormatter();
+	public static final DateTimeFormatter ISO8601_TIME_FORMAT = new DateTimeFormatterBuilder()
+			.appendValue(ChronoField.HOUR_OF_DAY, 2)
+			.appendLiteral(":")
+			.appendValue(ChronoField.MINUTE_OF_HOUR, 2)
+			.appendLiteral(":")
+			.appendValue(ChronoField.SECOND_OF_MINUTE, 2)
+			.appendFraction(ChronoField.MILLI_OF_SECOND, 0, 3, true)
+			.toFormatter();
+	public static final DateTimeFormatter ISO8601_YEARMONTH_FORMAT = new DateTimeFormatterBuilder()
+			.appendValue(ChronoField.YEAR)
+			.appendLiteral("-")
+			.appendValue(ChronoField.MONTH_OF_YEAR, 2)
+			.toFormatter();
+	public static final DateTimeFormatter ISO8601_YEAR_FORMAT = new DateTimeFormatterBuilder()
+			.appendValue(ChronoField.YEAR)
+			.toFormatter();
+
+	private static DateTimeFormatter toISO8601String(Temporal temporal, TimeZone timeZone) {
+		if (temporal instanceof LocalTime)
+			return ISO8601_TIME_FORMAT;
+		else if (temporal instanceof Year)
+			return ISO8601_YEAR_FORMAT;
+		else if (temporal instanceof YearMonth)
+			return ISO8601_YEARMONTH_FORMAT;
+		else
+			return ISO8601_FORMAT;
+	}
+
+	private static DateTimeFormatter toXSString(Temporal temporal, TimeZone timeZone) {
+		if (temporal instanceof LocalTime)
+			return XSD_TIME_FORMAT;
+		else if (temporal instanceof Year)
+			return ISO8601_YEAR_FORMAT;//ISO same as XSD here
+		else if (temporal instanceof YearMonth)
+			return XSD_YEARMONTH_FORMAT;
+		else
+			return XSD_FORMAT;
+	}
+
+	public static String format(Temporal temporal, String format, Locale locale, TimeZone timeZone) {
+		//TODO: cache these DateTimeFormatter instances (withLocale & withZone create new instances too, when they differ from the instance)
+		if (temporal instanceof Instant)
+			temporal = ((Instant) temporal).atZone(timeZone == null ? ZoneOffset.UTC : timeZone.toZoneId());
+
+		String[] formatSplt = format.split("_");
+		DateTimeFormatter dtf;
+		if ("xs".equals(format))
+			dtf = toXSString(temporal, timeZone);
+		else if ("iso".equals(format))
+			dtf =  toISO8601String(temporal, timeZone);
+		else if (FORMAT_STYLE_PATTERN.matcher(format).matches()) {
+			boolean isYear = temporal instanceof Year;
+			boolean isYearMonth = temporal instanceof YearMonth;
+			if (isYear || isYearMonth) {
+				String reducedPattern = DateTimeFormatterBuilder.getLocalizedDateTimePattern(FormatStyle.valueOf(formatSplt[0].toUpperCase()), null, IsoChronology.INSTANCE, locale);
+				if (isYear)
+					dtf = DateTimeFormatter.ofPattern(removeNonYM(reducedPattern, false));
+				else
+					dtf = DateTimeFormatter.ofPattern(removeNonYM(reducedPattern, true));
+			} else if ("short".equals(format))
+				dtf =  SHORT_FORMAT;
+			else if ("medium".equals(format))
+				dtf =  MEDIUM_FORMAT;
+			else if ("long".equals(format))
+				dtf =  LONG_FORMAT;
+			else if ("full".equals(format))
+				dtf = FULL_FORMAT;
+			else
+				dtf = DateTimeFormatter.ofLocalizedDateTime(FormatStyle.valueOf(formatSplt[0].toUpperCase()), FormatStyle.valueOf(formatSplt[1].toUpperCase()));
+		} else
+			dtf = DateTimeFormatter.ofPattern(format);
+
+		dtf = dtf.withLocale(locale);
+		if (temporal instanceof OffsetDateTime)
+			dtf = dtf.withZone(((OffsetDateTime) temporal).getOffset());
+		else if (!(temporal instanceof ZonedDateTime))
+			dtf = dtf.withZone(timeZone.toZoneId());
+		return dtf.format(temporal);
+	}
+
+	private static String removeNonYM(String pattern, boolean withMonth) {
+		boolean separator = false;
+		boolean copy = true;
+		StringBuilder newPattern = new StringBuilder();
+		for (char c : pattern.toCharArray()) {
+			if (c == '\'')
+				separator = !separator;
+			if (!separator && Character.isAlphabetic(c))
+				copy = c == 'y' || c == 'u' || (withMonth && (c == 'M' || c == 'L'));
+			if (copy)
+				newPattern.append(c);
+		}
+		return newPattern.toString();
+	}
+}

--- a/src/main/java/freemarker/template/utility/TemporalUtil.java
+++ b/src/main/java/freemarker/template/utility/TemporalUtil.java
@@ -19,8 +19,6 @@
 package freemarker.template.utility;
 
 import java.time.Instant;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.Year;
@@ -111,7 +109,7 @@ public class TemporalUtil {
 			.appendValue(ChronoField.YEAR)
 			.toFormatter();
 
-	private static DateTimeFormatter toISO8601String(Temporal temporal, TimeZone timeZone) {
+	private static DateTimeFormatter getISO8601Formatter(Temporal temporal, TimeZone timeZone) {
 		if (temporal instanceof LocalTime)
 			return ISO8601_TIME_FORMAT;
 		else if (temporal instanceof Year)
@@ -122,7 +120,7 @@ public class TemporalUtil {
 			return ISO8601_FORMAT;
 	}
 
-	private static DateTimeFormatter toXSString(Temporal temporal, TimeZone timeZone) {
+	private static DateTimeFormatter getXSFormatter(Temporal temporal, TimeZone timeZone) {
 		if (temporal instanceof LocalTime)
 			return XSD_TIME_FORMAT;
 		else if (temporal instanceof Year)
@@ -141,9 +139,9 @@ public class TemporalUtil {
 		String[] formatSplt = format.split("_");
 		DateTimeFormatter dtf;
 		if ("xs".equals(format))
-			dtf = toXSString(temporal, timeZone);
+			dtf = getXSFormatter(temporal, timeZone);
 		else if ("iso".equals(format))
-			dtf =  toISO8601String(temporal, timeZone);
+			dtf =  getISO8601Formatter(temporal, timeZone);
 		else if (FORMAT_STYLE_PATTERN.matcher(format).matches()) {
 			boolean isYear = temporal instanceof Year;
 			boolean isYearMonth = temporal instanceof YearMonth;
@@ -163,8 +161,10 @@ public class TemporalUtil {
 				dtf = FULL_FORMAT;
 			else
 				dtf = DateTimeFormatter.ofLocalizedDateTime(FormatStyle.valueOf(formatSplt[0].toUpperCase()), FormatStyle.valueOf(formatSplt[1].toUpperCase()));
-		} else
+		} else if (!"".equals(format))
 			dtf = DateTimeFormatter.ofPattern(format);
+		else
+			return temporal.toString();
 
 		dtf = dtf.withLocale(locale);
 		if (temporal instanceof OffsetDateTime)

--- a/src/main/java/freemarker/template/utility/TemporalUtil.java
+++ b/src/main/java/freemarker/template/utility/TemporalUtil.java
@@ -109,7 +109,7 @@ public class TemporalUtil {
 			.appendValue(ChronoField.YEAR)
 			.toFormatter();
 
-	private static DateTimeFormatter getISO8601Formatter(Temporal temporal, TimeZone timeZone) {
+	private static DateTimeFormatter getISO8601Formatter(Temporal temporal) {
 		if (temporal instanceof LocalTime)
 			return ISO8601_TIME_FORMAT;
 		else if (temporal instanceof Year)
@@ -120,7 +120,7 @@ public class TemporalUtil {
 			return ISO8601_FORMAT;
 	}
 
-	private static DateTimeFormatter getXSFormatter(Temporal temporal, TimeZone timeZone) {
+	private static DateTimeFormatter getXSFormatter(Temporal temporal) {
 		if (temporal instanceof LocalTime)
 			return XSD_TIME_FORMAT;
 		else if (temporal instanceof Year)
@@ -139,9 +139,9 @@ public class TemporalUtil {
 		String[] formatSplt = format.split("_");
 		DateTimeFormatter dtf;
 		if ("xs".equals(format))
-			dtf = getXSFormatter(temporal, timeZone);
+			dtf = getXSFormatter(temporal);
 		else if ("iso".equals(format))
-			dtf =  getISO8601Formatter(temporal, timeZone);
+			dtf =  getISO8601Formatter(temporal);
 		else if (FORMAT_STYLE_PATTERN.matcher(format).matches()) {
 			boolean isYear = temporal instanceof Year;
 			boolean isYearMonth = temporal instanceof YearMonth;

--- a/src/test/java/freemarker/test/templatesuite/TemplateTestCase.java
+++ b/src/test/java/freemarker/test/templatesuite/TemplateTestCase.java
@@ -26,6 +26,13 @@ import java.io.StringWriter;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.time.Year;
+import java.time.YearMonth;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.temporal.Temporal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -347,6 +354,18 @@ public class TemplateTestCase extends FileTestCase {
             dataModel.put("timeOnly", new java.sql.Time(d.getTime()));
             dataModel.put("dateOnly", new java.sql.Date(d.getTime()));
             dataModel.put("dateTime", new java.sql.Timestamp(d.getTime()));
+        } else if (simpleTestName.equals("temporal")) {
+            LocalDateTime ldt = LocalDateTime.of(2003, 4, 5, 6, 7, 8);
+            dataModel.put("dateTime", new java.sql.Timestamp(103, 4 - 1, 5, 8, 7, 8, 0));
+            dataModel.put("instant", ldt.toInstant(ZoneOffset.UTC));
+            dataModel.put("localDateTime", ldt);
+            dataModel.put("localDate", ldt.toLocalDate());
+            dataModel.put("localTime", ldt.toLocalTime());
+            dataModel.put("year", Year.from(ldt));
+            dataModel.put("yearMonth", YearMonth.from(ldt));
+            ZonedDateTime zdt = ldt.atZone(ZoneId.of("UTC"));
+            dataModel.put("offsetDateTime", zdt.toOffsetDateTime());
+            dataModel.put("zonedDateTime", zdt);
         } else if (simpleTestName.equals("var-layers")) {
             dataModel.put("x", Integer.valueOf(4));
             dataModel.put("z", Integer.valueOf(4));

--- a/src/test/java/freemarker/test/templatesuite/models/AllTemplateModels.java
+++ b/src/test/java/freemarker/test/templatesuite/models/AllTemplateModels.java
@@ -19,6 +19,8 @@
 
 package freemarker.test.templatesuite.models;
 
+import java.time.Instant;
+import java.time.temporal.Temporal;
 import java.util.Date;
 
 import freemarker.template.SimpleScalar;
@@ -32,13 +34,14 @@ import freemarker.template.TemplateModelIterator;
 import freemarker.template.TemplateNumberModel;
 import freemarker.template.TemplateScalarModel;
 import freemarker.template.TemplateSequenceModel;
+import freemarker.template.TemplateTemporalModel;
 
 /**
  * Implements all template models that are interesting when calling overloaded Java methods.
  */
 public class AllTemplateModels implements
-        TemplateScalarModel, TemplateNumberModel, TemplateDateModel, TemplateBooleanModel,
-        TemplateHashModelEx, TemplateSequenceModel, TemplateCollectionModel {
+        TemplateScalarModel, TemplateNumberModel, TemplateDateModel, TemplateTemporalModel,
+        TemplateBooleanModel, TemplateHashModelEx, TemplateSequenceModel, TemplateCollectionModel {
 
     public static final AllTemplateModels INSTANCE = new AllTemplateModels();
     
@@ -95,6 +98,10 @@ public class AllTemplateModels implements
 
     public Date getAsDate() throws TemplateModelException {
         return new Date(0);
+    }
+
+    public Temporal getAsTemporal() throws TemplateModelException {
+        return Instant.ofEpochMilli(0);
     }
 
     public int getDateType() {

--- a/src/test/java/freemarker/test/utility/AssertEqualsDirective.java
+++ b/src/test/java/freemarker/test/utility/AssertEqualsDirective.java
@@ -33,6 +33,7 @@ import freemarker.template.TemplateModel;
 import freemarker.template.TemplateModelException;
 import freemarker.template.TemplateNumberModel;
 import freemarker.template.TemplateScalarModel;
+import freemarker.template.TemplateTemporalModel;
 import freemarker.template.utility.StringUtil;
 
 public class AssertEqualsDirective implements TemplateDirectiveModel {
@@ -81,6 +82,7 @@ public class AssertEqualsDirective implements TemplateDirectiveModel {
         // This is the same order as comparison goes:
         else if (value instanceof TemplateNumberModel) return ((TemplateNumberModel) value).getAsNumber().toString();
         else if (value instanceof TemplateDateModel) return ((TemplateDateModel) value).getAsDate().toString();
+        else if (value instanceof TemplateTemporalModel) return ((TemplateTemporalModel) value).getAsTemporal().toString();
         else if (value instanceof TemplateScalarModel) return StringUtil.jQuote(((TemplateScalarModel) value).getAsString());
         else if (value instanceof TemplateBooleanModel) return String.valueOf(((TemplateBooleanModel) value).getAsBoolean());
         // This shouldn't be reached, as the comparison should have failed earlier:

--- a/src/test/resources/freemarker/test/templatesuite/templates/temporal.ftl
+++ b/src/test/resources/freemarker/test/templatesuite/templates/temporal.ftl
@@ -110,17 +110,17 @@
 <#setting locale="en_US">
 <#setting instantFormat="yyyy MMM dd HH:mm:ss">
 <@assertEquals expected="2003 Apr 05 01:07:08" actual=instant?string />
-<#setting localdatetimeFormat="yyyy MMM dd HH:mm:ss">
+<#setting localDateTimeFormat="yyyy MMM dd HH:mm:ss">
 <@assertEquals expected="2003 Apr 05 06:07:08" actual=localDateTime?string />
-<#setting localdateFormat="yyyy MMM dd">
+<#setting localDateFormat="yyyy MMM dd">
 <@assertEquals expected="2003 Apr 05" actual=localDate?string />
-<#setting localdatetimeFormat="HH:mm:ss">
+<#setting localDateTimeFormat="HH:mm:ss">
 <@assertEquals expected="06:07:08" actual=localTime?string />
-<#setting offsetdatetimeFormat="yyyy MMM dd HH:mm:ss">
+<#setting offsetDateTimeFormat="yyyy MMM dd HH:mm:ss">
 <@assertEquals expected="2003 Apr 05 06:07:08" actual=offsetDateTime?string />
 <#setting yearFormat="yyyy">
 <@assertEquals expected="2003" actual=year?string />
-<#setting yearmonthFormat="yyyy MMM">
+<#setting yearMonthFormat="yyyy MMM">
 <@assertEquals expected="2003 Apr" actual=yearMonth?string />
-<#setting zoneddatetimeFormat="yyyy MMM dd HH:mm:ss">
+<#setting zonedDateTimeFormat="yyyy MMM dd HH:mm:ss">
 <@assertEquals expected="2003 Apr 05 06:07:08" actual=zonedDateTime?string />

--- a/src/test/resources/freemarker/test/templatesuite/templates/temporal.ftl
+++ b/src/test/resources/freemarker/test/templatesuite/templates/temporal.ftl
@@ -1,0 +1,103 @@
+<#--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<#setting timeZone="America/New_York">
+<@assertEquals expected="2003-04-05T06:07:08" actual=localDateTime?string.iso />
+<@assertEquals expected="2003-04-05T01:07:08-05:00" actual=instant?string.iso />
+<@assertEquals expected="2003-04-05" actual=localDate?string.iso />
+<@assertEquals expected="06:07:08" actual=localTime?string.iso />
+<@assertEquals expected="2003-04-05T06:07:08Z" actual=zonedDateTime?string.iso />
+<@assertEquals expected="2003-04-05T06:07:08Z" actual=offsetDateTime?string.iso />
+<@assertEquals expected="2003" actual=year?string.iso />
+<@assertEquals expected="2003-04" actual=yearMonth?string.iso />
+
+<#setting timeZone="UTC">
+<@assertEquals expected="2003-04-05T06:07:08" actual=localDateTime?string.iso />
+<@assertEquals expected="2003-04-05T06:07:08Z" actual=instant?string.iso />
+<@assertEquals expected="2003-04-05" actual=localDate?string.iso />
+<@assertEquals expected="06:07:08" actual=localTime?string.iso />
+<@assertEquals expected="2003-04-05T06:07:08Z" actual=zonedDateTime?string.iso />
+<@assertEquals expected="2003-04-05T06:07:08Z" actual=offsetDateTime?string.iso />
+<@assertEquals expected="2003" actual=year?string.iso />
+<@assertEquals expected="2003-04" actual=yearMonth?string.iso />
+
+<@assertEquals expected="2003-04-05T06:07:08" actual=localDateTime?string.xs />
+<@assertEquals expected="2003-04-05T06:07:08Z" actual=instant?string.xs />
+<@assertEquals expected="2003-04-05" actual=localDate?string.xs />
+<@assertEquals expected="06:07:08" actual=localTime?string.xs />
+<@assertEquals expected="2003-04-05T06:07:08Z" actual=zonedDateTime?string.xs />
+<@assertEquals expected="2003-04-05T06:07:08Z" actual=offsetDateTime?string.xs />
+<@assertEquals expected="2003" actual=year?string.xs />
+<@assertEquals expected="2003-04" actual=yearMonth?string.xs />
+
+<#setting timeZone="America/New_York">
+<#setting locale="fr_FR">
+<@assertEquals expected="05/04/03 01:07" actual=instant?string.short />
+<@assertEquals expected="5 avr. 2003 01:07:08" actual=instant?string.medium />
+<@assertEquals expected="5 avril 2003 01:07:08 EST" actual=instant?string.long />
+<@assertEquals expected="samedi 5 avril 2003 01 h 07 EST" actual=instant?string.full />
+
+<@assertEquals expected="05/04/03 06:07" actual=zonedDateTime?string.short />
+<@assertEquals expected="5 avr. 2003 06:07:08" actual=zonedDateTime?string.medium />
+<@assertEquals expected="5 avril 2003 06:07:08 UTC" actual=zonedDateTime?string.long />
+<@assertEquals expected="samedi 5 avril 2003 06 h 07 UTC" actual=zonedDateTime?string.full />
+
+<@assertEquals expected="05/04/03 06:07" actual=offsetDateTime?string.short />
+<@assertEquals expected="5 avr. 2003 06:07:08" actual=offsetDateTime?string.medium />
+<@assertEquals expected="5 avril 2003 06:07:08 Z" actual=offsetDateTime?string.long />
+<@assertEquals expected="samedi 5 avril 2003 06 h 07 Z" actual=offsetDateTime?string.full />
+
+<@assertEquals expected="05/04/03 06:07" actual=localDateTime?string.short />
+<@assertEquals expected="5 avr. 2003 06:07:08" actual=localDateTime?string.medium />
+<@assertEquals expected="5 avril 2003 06:07:08 ET" actual=localDateTime?string.long />
+<@assertEquals expected="samedi 5 avril 2003 06 h 07 ET" actual=localDateTime?string.full />
+
+<@assertEquals expected="03" actual=year?string.short />
+<@assertEquals expected="2003" actual=year?string.medium />
+<@assertEquals expected="2003" actual=year?string.long />
+<@assertEquals expected="2003" actual=year?string.full />
+
+<@assertEquals expected="04/03" actual=yearMonth?string.short />
+<@assertEquals expected="avr. 2003" actual=yearMonth?string.medium />
+<@assertEquals expected="avril 2003" actual=yearMonth?string.long />
+<@assertEquals expected="avril 2003" actual=yearMonth?string.full />
+<#setting locale="es_ES">
+<@assertEquals expected="abril de 2003" actual=yearMonth?string.full />
+<#setting locale="fr_FR">
+
+<@assertEquals expected="05/04/03 06:07" actual=localDateTime?string.short_short />
+<@assertEquals expected="05/04/03 06:07:08" actual=localDateTime?string.short_medium />
+<@assertEquals expected="05/04/03 06:07:08 ET" actual=localDateTime?string.short_long />
+<@assertEquals expected="05/04/03 06 h 07 ET" actual=localDateTime?string.short_full />
+
+<@assertEquals expected="5 avr. 2003 06:07:08" actual=localDateTime?string.medium_medium />
+<@assertEquals expected="5 avril 2003 06:07:08" actual=localDateTime?string.long_medium />
+<@assertEquals expected="samedi 5 avril 2003 06:07:08" actual=localDateTime?string.full_medium />
+
+<@assertEquals expected="5 avril 2003 06:07:08 ET" actual=localDateTime?string.long_long />
+<@assertEquals expected="samedi 5 avril 2003 06:07:08 ET" actual=localDateTime?string.full_long />
+
+<@assertEquals expected="samedi 5 avril 2003 06 h 07 ET" actual=localDateTime?string.full_full />
+
+<@assertEquals expected="2003-04-05" actual=localDateTime?string('yyyy-MM-dd') />
+<@assertEquals expected="2003-04-05 06:07:08" actual=localDateTime?string('yyyy-MM-dd HH:mm:ss') />
+
+
+<#setting temporalFormat="yyyy MMM dd HH:mm:ss">
+<#setting locale="en_US">
+<@assertEquals expected="2003 Apr 05 06:07:08" actual=localDateTime?string />

--- a/src/test/resources/freemarker/test/templatesuite/templates/temporal.ftl
+++ b/src/test/resources/freemarker/test/templatesuite/templates/temporal.ftl
@@ -16,34 +16,43 @@
   specific language governing permissions and limitations
   under the License.
 -->
+<@assertEquals expected="2003-04-05T07:07:08+01:00[GMT+01:00]" actual=instant?string />
+<@assertEquals expected="2003-04-05T06:07:08" actual=localDateTime?string />
+<@assertEquals expected="2003-04-05" actual=localDate?string />
+<@assertEquals expected="06:07:08" actual=localTime?string />
+<@assertEquals expected="2003-04-05T06:07:08Z" actual=offsetDateTime?string />
+<@assertEquals expected="2003" actual=year?string />
+<@assertEquals expected="2003-04" actual=yearMonth?string />
+<@assertEquals expected="2003-04-05T06:07:08Z[UTC]" actual=zonedDateTime?string />
+
 <#setting timeZone="America/New_York">
-<@assertEquals expected="2003-04-05T06:07:08" actual=localDateTime?string.iso />
 <@assertEquals expected="2003-04-05T01:07:08-05:00" actual=instant?string.iso />
+<@assertEquals expected="2003-04-05T06:07:08" actual=localDateTime?string.iso />
 <@assertEquals expected="2003-04-05" actual=localDate?string.iso />
 <@assertEquals expected="06:07:08" actual=localTime?string.iso />
-<@assertEquals expected="2003-04-05T06:07:08Z" actual=zonedDateTime?string.iso />
 <@assertEquals expected="2003-04-05T06:07:08Z" actual=offsetDateTime?string.iso />
 <@assertEquals expected="2003" actual=year?string.iso />
 <@assertEquals expected="2003-04" actual=yearMonth?string.iso />
+<@assertEquals expected="2003-04-05T06:07:08Z" actual=zonedDateTime?string.iso />
 
 <#setting timeZone="UTC">
-<@assertEquals expected="2003-04-05T06:07:08" actual=localDateTime?string.iso />
 <@assertEquals expected="2003-04-05T06:07:08Z" actual=instant?string.iso />
+<@assertEquals expected="2003-04-05T06:07:08" actual=localDateTime?string.iso />
 <@assertEquals expected="2003-04-05" actual=localDate?string.iso />
 <@assertEquals expected="06:07:08" actual=localTime?string.iso />
-<@assertEquals expected="2003-04-05T06:07:08Z" actual=zonedDateTime?string.iso />
 <@assertEquals expected="2003-04-05T06:07:08Z" actual=offsetDateTime?string.iso />
 <@assertEquals expected="2003" actual=year?string.iso />
 <@assertEquals expected="2003-04" actual=yearMonth?string.iso />
+<@assertEquals expected="2003-04-05T06:07:08Z" actual=zonedDateTime?string.iso />
 
-<@assertEquals expected="2003-04-05T06:07:08" actual=localDateTime?string.xs />
 <@assertEquals expected="2003-04-05T06:07:08Z" actual=instant?string.xs />
+<@assertEquals expected="2003-04-05T06:07:08" actual=localDateTime?string.xs />
 <@assertEquals expected="2003-04-05" actual=localDate?string.xs />
 <@assertEquals expected="06:07:08" actual=localTime?string.xs />
-<@assertEquals expected="2003-04-05T06:07:08Z" actual=zonedDateTime?string.xs />
 <@assertEquals expected="2003-04-05T06:07:08Z" actual=offsetDateTime?string.xs />
 <@assertEquals expected="2003" actual=year?string.xs />
 <@assertEquals expected="2003-04" actual=yearMonth?string.xs />
+<@assertEquals expected="2003-04-05T06:07:08Z" actual=zonedDateTime?string.xs />
 
 <#setting timeZone="America/New_York">
 <#setting locale="fr_FR">
@@ -51,11 +60,6 @@
 <@assertEquals expected="5 avr. 2003 01:07:08" actual=instant?string.medium />
 <@assertEquals expected="5 avril 2003 01:07:08 EST" actual=instant?string.long />
 <@assertEquals expected="samedi 5 avril 2003 01 h 07 EST" actual=instant?string.full />
-
-<@assertEquals expected="05/04/03 06:07" actual=zonedDateTime?string.short />
-<@assertEquals expected="5 avr. 2003 06:07:08" actual=zonedDateTime?string.medium />
-<@assertEquals expected="5 avril 2003 06:07:08 UTC" actual=zonedDateTime?string.long />
-<@assertEquals expected="samedi 5 avril 2003 06 h 07 UTC" actual=zonedDateTime?string.full />
 
 <@assertEquals expected="05/04/03 06:07" actual=offsetDateTime?string.short />
 <@assertEquals expected="5 avr. 2003 06:07:08" actual=offsetDateTime?string.medium />
@@ -80,6 +84,11 @@
 <@assertEquals expected="abril de 2003" actual=yearMonth?string.full />
 <#setting locale="fr_FR">
 
+<@assertEquals expected="05/04/03 06:07" actual=zonedDateTime?string.short />
+<@assertEquals expected="5 avr. 2003 06:07:08" actual=zonedDateTime?string.medium />
+<@assertEquals expected="5 avril 2003 06:07:08 UTC" actual=zonedDateTime?string.long />
+<@assertEquals expected="samedi 5 avril 2003 06 h 07 UTC" actual=zonedDateTime?string.full />
+
 <@assertEquals expected="05/04/03 06:07" actual=localDateTime?string.short_short />
 <@assertEquals expected="05/04/03 06:07:08" actual=localDateTime?string.short_medium />
 <@assertEquals expected="05/04/03 06:07:08 ET" actual=localDateTime?string.short_long />
@@ -98,6 +107,20 @@
 <@assertEquals expected="2003-04-05 06:07:08" actual=localDateTime?string('yyyy-MM-dd HH:mm:ss') />
 
 
-<#setting temporalFormat="yyyy MMM dd HH:mm:ss">
 <#setting locale="en_US">
+<#setting instantFormat="yyyy MMM dd HH:mm:ss">
+<@assertEquals expected="2003 Apr 05 01:07:08" actual=instant?string />
+<#setting localdatetimeFormat="yyyy MMM dd HH:mm:ss">
 <@assertEquals expected="2003 Apr 05 06:07:08" actual=localDateTime?string />
+<#setting localdateFormat="yyyy MMM dd">
+<@assertEquals expected="2003 Apr 05" actual=localDate?string />
+<#setting localdatetimeFormat="HH:mm:ss">
+<@assertEquals expected="06:07:08" actual=localTime?string />
+<#setting offsetdatetimeFormat="yyyy MMM dd HH:mm:ss">
+<@assertEquals expected="2003 Apr 05 06:07:08" actual=offsetDateTime?string />
+<#setting yearFormat="yyyy">
+<@assertEquals expected="2003" actual=year?string />
+<#setting yearmonthFormat="yyyy MMM">
+<@assertEquals expected="2003 Apr" actual=yearMonth?string />
+<#setting zoneddatetimeFormat="yyyy MMM dd HH:mm:ss">
+<@assertEquals expected="2003 Apr 05 06:07:08" actual=zonedDateTime?string />

--- a/src/test/resources/freemarker/test/templatesuite/testcases.xml
+++ b/src/test/resources/freemarker/test/templatesuite/testcases.xml
@@ -220,6 +220,7 @@
       <setting incompatible_improvements="2.3.24, max"/>
    </testCase>
    <testCase name="date-type-builtins" noOutput="true" />
+   <testCase name="temporal" noOutput="true" />
    <testCase name="url" noOutput="true" />
    <testCase name="var-layers"/>
    <testCase name="variables"/>


### PR DESCRIPTION
Support for Java8 temporal formatting (from temporal to string).

The supported temporal types are:
java.time.Instant;
java.time.LocalDate;
java.time.LocalDateTime;
java.time.LocalTime;
java.time.OffsetDateTime;
java.time.OffsetTime;
java.time.Year;
java.time.YearMonth;
java.time.ZonedDateTime;