### PR TITLE
Add a TravisCI job to run the build and tests on ARM64 architecture

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ addons:
 
 cache:
   directories:
-    - $HOME/.ivy/cache
+    - $HOME/.ivy-freemarker/cache
 
 before_install:
   - lscpu

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,19 +22,16 @@ arch:
   - amd64
   - arm64
 
-install:
+addons:
+  apt:
+    packages:
+      - openjdk-8-jdk
+      - ant
+
+before_install:
   - lscpu
-  - ARCH=`uname -p`
-  - echo $ARCH
-  - JDK_X64="https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u272-b10/OpenJDK8U-jdk_x64_linux_hotspot_8u272b10.tar.gz"
-  - JDK_ARM64="https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u272-b10/OpenJDK8U-jdk_aarch64_linux_hotspot_8u272b10.tar.gz"
-  - if test "X$ARCH" = "Xaarch64"; then JDK_URL=$JDK_ARM64; else JDK_URL=$JDK_X64; fi
-  - wget -q $JDK_URL && tar xzf OpenJDK*.tar.gz
-  - mv jdk8* jdk
-  - export JAVA_HOME=`pwd`/jdk
-  - wget -q https://mirrors.netix.net/apache/ant/binaries/apache-ant-1.10.9-bin.tar.gz && tar xzf apache-ant-*-bin.tar.gz
-  - export ANT_HOME=`pwd`/apache-ant-1.10.9
-  - export PATH="$JAVA_HOME/bin:$ANT_HOME/bin:$PATH"
+
+install:
   - java -version
   - ant -version
   - ant download-ivy  

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,12 +15,29 @@
 # specific language governing permissions and limitations
 # under the License.
 
-language: java
-before_install:
-- sudo apt-get -qq update
-# ant-optional is needed for ant junit
-- sudo apt-get install ant-optional
-install: ant download-ivy
-script: ant ci
-jdk:
-  - openjdk8
+os: linux
+dist: focal
+
+arch:
+  - amd64
+  - arm64
+
+install:
+  - lscpu
+  - ARCH=`uname -p`
+  - echo $ARCH
+  - JDK_X64="https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u272-b10/OpenJDK8U-jdk_x64_linux_hotspot_8u272b10.tar.gz"
+  - JDK_ARM64="https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u272-b10/OpenJDK8U-jdk_aarch64_linux_hotspot_8u272b10.tar.gz"
+  - if test "X$ARCH" = "Xaarch64"; then JDK_URL=$JDK_ARM64; else JDK_URL=$JDK_X64; fi
+  - wget -q $JDK_URL && tar xzf OpenJDK*.tar.gz
+  - mv jdk8* jdk
+  - export JAVA_HOME=`pwd`/jdk
+  - wget -q https://mirrors.netix.net/apache/ant/binaries/apache-ant-1.10.9-bin.tar.gz && tar xzf apache-ant-*-bin.tar.gz
+  - export ANT_HOME=`pwd`/apache-ant-1.10.9
+  - export PATH="$JAVA_HOME/bin:$ANT_HOME/bin:$PATH"
+  - java -version
+  - ant -version
+  - ant download-ivy  
+
+script: 
+  - ant ci  

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ addons:
   apt:
     packages:
       - openjdk-8-jdk
-      - ant-contrib
+      - ant-optional
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ addons:
   apt:
     packages:
       - openjdk-8-jdk
-      - ant
+      - ant-contrib
 
 before_install:
   - lscpu

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,10 +36,10 @@ before_install:
   - lscpu
   - export JAVA_HOME="/usr/lib/jvm/java-8-openjdk-${TRAVIS_CPU_ARCH}/"
   - export PATH="$JAVA_HOME/bin:$PATH"
-
-install:
   - java -version
   - ant -version
+
+install:
   - ant download-ivy  
 
 script: 

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,10 @@ addons:
       - openjdk-8-jdk
       - ant-contrib
 
+cache:
+  directories:
+    - $HOME/.ivy/cache
+
 before_install:
   - lscpu
   - export JAVA_HOME="/usr/lib/jvm/java-8-openjdk-${TRAVIS_CPU_ARCH}/"

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,8 @@ addons:
 
 before_install:
   - lscpu
+  - export JAVA_HOME="/usr/lib/jvm/java-8-openjdk-${TRAVIS_CPU_ARCH}/"
+  - export PATH="$JAVA_HOME/bin:$PATH"
 
 install:
   - java -version


### PR DESCRIPTION
More and more software deployment and deployment is being done on ARM64 CPU architecture.
It would be good if Apache FreeMarker is being regularly tested on ARM64.

I've changed the way OpenJDK and Ant are installed because they are different versions on AMD64 and ARM64 VMs at TravisCI. Now they are installed manually but this way it is easier to install specific/newer versions when needed. Let me know if you prefer the old way and I will revert to it!