### PR TITLE
fix typo 'TemplatException' to 'TemplateException'

### DIFF
--- a/src/manual/en_US/book.xml
+++ b/src/manual/en_US/book.xml
@@ -8950,15 +8950,15 @@ cfg.setTemplateLoader(mtl);</programlisting>
                 </listitem>
 
                 <listitem>
-                  <para><literal>freemarker.template.TemplatException</literal>
+                  <para><literal>freemarker.template.TemplateException</literal>
                   because other problem occurred while executing the template.
                   For example, a frequent error is referring to a variable
                   that doesn't exist in the data-model. By default, when a
-                  <literal>TemplatException</literal> occurs, FreeMarker
+                  <literal>TemplateException</literal> occurs, FreeMarker
                   prints the FTL error message and the stack trace to the
                   output writer with plain text format, and then aborts the
                   template execution by re-throwing the
-                  <literal>TemplatException</literal>, which then you can
+                  <literal>TemplateException</literal>, which then you can
                   catch as
                   <literal>Template.process(<replaceable>...</replaceable>)</literal>
                   throws it. This behavior can be customized, and in fact, it
@@ -8966,7 +8966,7 @@ cfg.setTemplateLoader(mtl);</programlisting>
                   linkend="pgui_quickstart_createconfiguration">here</link>.
                   By default FreeMarker also <link
                   linkend="pgui_misc_logging">logs</link>
-                  <literal>TemplatException</literal>-s.</para>
+                  <literal>TemplateException</literal>-s.</para>
                 </listitem>
               </itemizedlist>
             </listitem>
@@ -8974,7 +8974,7 @@ cfg.setTemplateLoader(mtl);</programlisting>
         </section>
 
         <section>
-          <title>Customizing the behavior regarding TemplatException-s</title>
+          <title>Customizing the behavior regarding TemplateException-s</title>
 
           <para><literal>TemplateException</literal>-s thrown during the
           template processing are handled by the

--- a/src/manual/zh_CN/book.xml
+++ b/src/manual/zh_CN/book.xml
@@ -6922,14 +6922,14 @@ cfg.setTemplateLoader(mtl);</programlisting>
 
                 <listitem>
                   <para>当执行模板时发生的其它问题而导致的 
-				  <literal>freemarker.template.TemplatException</literal> 异常。
+				  <literal>freemarker.template.TemplateException</literal> 异常。
 				  比如，一个频繁发生的错误，就是当模板引用一个不存在的变量。
-				  默认情况下，当 <literal>TemplatException</literal> 异常发生时，
+				  默认情况下，当 <literal>TemplateException</literal> 异常发生时，
 				  FreeMarker会用普通文本格式在输出中打印出FTL的错误信息和堆栈跟踪信息，
-				  然后再次抛出 <literal>TemplatException</literal> 异常而中止模板的执行，
+				  然后再次抛出 <literal>TemplateException</literal> 异常而中止模板的执行，
 				  就可以捕捉到 <literal>Template.process(<replaceable>...</replaceable>)</literal> 
 				  方法抛出的异常了。而这种行为是可以定制的。FreeMarker也会经常写 
-				  <literal>TemplatException</literal> 异常的 
+				  <literal>TemplateException</literal> 异常的 
 				  <link linkend="pgui_misc_logging">日志</link>。</para>
                 </listitem>
               </itemizedlist>


### PR DESCRIPTION
Fix typo 'TemplatException' to 'TemplateException' in src/manual/en_US/book.xml and src/manual/zh_CN/book.xml.

Typo was found on this page: https://freemarker.apache.org/docs/pgui_config_errorhandling.html