### PR TITLE
replace String by StringBuilder in ElementModel

### DIFF
--- a/src/main/java/freemarker/ext/dom/ElementModel.java
+++ b/src/main/java/freemarker/ext/dom/ElementModel.java
@@ -131,21 +131,21 @@ class ElementModel extends NodeModel implements TemplateScalarModel {
     @Override
     public String getAsString() throws TemplateModelException {
         NodeList nl = node.getChildNodes();
-        String result = "";
+        StringBuilder result = new StringBuilder();
         for (int i = 0; i < nl.getLength(); i++) {
             Node child = nl.item(i);
             int nodeType = child.getNodeType();
             if (nodeType == Node.ELEMENT_NODE) {
                 String msg = "Only elements with no child elements can be processed as text."
-                             + "\nThis element with name \""
-                             + node.getNodeName()
-                             + "\" has a child element named: " + child.getNodeName();
+                        + "\nThis element with name \""
+                        + node.getNodeName()
+                        + "\" has a child element named: " + child.getNodeName();
                 throw new TemplateModelException(msg);
             } else if (nodeType == Node.TEXT_NODE || nodeType == Node.CDATA_SECTION_NODE) {
-                result += child.getNodeValue();
+                result.append(child.getNodeValue());
             }
         }
-        return result;
+        return result.toString();
     }
     
     @Override


### PR DESCRIPTION
I had a problem when using Freemarker with xml 's containing large content ( > 600KB)
The number of nodes were high, more then 10 000 and when using String concatenation as in the following snippet the performance was/is very poor.

 _if (nodeType == Node.ELEMENT_NODE) {
                String msg = "Only elements with no child elements can be processed as text."
                             + "\nThis element with name \""
                             + node.getNodeName()
                             + "\" has a child element named: " + child.getNodeName();
                throw new TemplateModelException(msg);
            } else if (nodeType == Node.TEXT_NODE || nodeType == Node.CDATA_SECTION_NODE) {
                result += child.getNodeValue();
            }_

For a xml file of 600kb this took 6 to 11 seconds to process.
When using a StringBuilder this takes 60 ms.
