### PR TITLE
Add support for bndtools in Eclipse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -30,6 +30,7 @@
 .classpath
 .project
 .settings
+bnd.bnd
 
 .idea/
 *.iml

--- a/build.xml
+++ b/build.xml
@@ -7,9 +7,9 @@
   to you under the Apache License, Version 2.0 (the
   "License"); you may not use this file except in compliance
   with the License.  You may obtain a copy of the License at
-  
+
     http://www.apache.org/licenses/LICENSE-2.0
-  
+
   Unless required by applicable law or agreed to in writing,
   software distributed under the License is distributed on an
   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -41,7 +41,7 @@
 
   <!-- Will be overidden on the Continous Integration server: -->
   <property name="server.ivy.repo.root" value="${basedir}/build/dummy-server-ivy-repo" />
-  
+
   <property file="build.properties"/>
   <condition property="has.explicit.boot.classpath.j2se1.7">
     <isset property="boot.classpath.j2se1.7"/>
@@ -60,17 +60,17 @@
   <!-- Note: Target "dist" doesn't allow using these. -->
   <property name="boot.classpath.j2se1.7" value="${sun.boot.class.path}" />
   <property name="boot.classpath.j2se1.8" value="${sun.boot.class.path}" />
-  
+
   <!-- For checking the correctness of the boot.classpath.j2se* -->
   <available classpath="${boot.classpath.j2se1.7}"
-    classname="java.nio.file.Path" ignoresystemclasses="true" 
+    classname="java.nio.file.Path" ignoresystemclasses="true"
     property="boot.classpath.j2se1.7.correct"
   />
   <available classpath="${boot.classpath.j2se1.8}"
-    classname="java.time.Instant" ignoresystemclasses="true" 
+    classname="java.time.Instant" ignoresystemclasses="true"
     property="boot.classpath.j2se1.8.correct"
   />
-  
+
   <!-- Set up version/timestamp filters and the version property: -->
   <tstamp>
     <format property="timestampNice" pattern="yyyy-MM-dd'T'HH:mm:ss'Z'"
@@ -91,17 +91,17 @@
   <property file="build/version.properties.tmp" />
   <delete file="build/version.properties.tmp" />
   <filter token="version" value="${version}" />
-  
+
   <property name="dist.dir" value="build/dist" />
   <property name="dist.archiveBaseName" value="apache-${mavenArtifactId}-${mavenVersion}" />
   <property name="dist.bin.dir" value="${dist.dir}/bin/${dist.archiveBaseName}-bin" />
   <property name="dist.src.dir" value="${dist.dir}/src/${dist.archiveBaseName}-src" />
-  
+
   <!-- ================================================================== -->
   <!-- Initialization                                                     -->
   <!-- ================================================================== -->
 
-  
+
   <target name="clean" description="get rid of all generated files">
     <delete dir="build" />
     <delete dir="META-INF" />
@@ -126,11 +126,11 @@
     <get src="https://repo1.maven.org/maven2/org/apache/ivy/ivy/${ivy.install.version}/ivy-${ivy.install.version}.jar"
          dest="${ivy.jar.file}" usetimestamp="true"/>
   </target>
-  
+
   <!-- ================================================================= -->
   <!-- Compilation                                                       -->
   <!-- ================================================================= -->
-  
+
   <target name="javacc" depends="init" unless="parser.uptodate"
     description="Build the parser from its grammar file"
   >
@@ -139,7 +139,7 @@
       uri="http://javacc.dev.java.net/"
       classpathref="ivy.dep"
     />
-    
+
     <property name="_javaccOutputDir"
       value="build/generated-sources/java/freemarker/core/"
     />
@@ -152,7 +152,7 @@
       javacchome="build/javacc-home.tmp"
     />
     <delete dir="build/javacc-home.tmp" />
-    
+
     <replace
       file="${_javaccOutputDir}/FMParser.java"
       token="private final LookaheadSuccess"
@@ -183,18 +183,18 @@
       token="enum"
       value="ENUM"
     />
-    
+
     <!-- As we have a modified version in src/main/java: -->
-    <move 
+    <move
       file="${_javaccOutputDir}/ParseException.java"
       tofile="${_javaccOutputDir}/ParseException.java.ignore"
     />
-    <move 
+    <move
       file="${_javaccOutputDir}/TokenMgrError.java"
       tofile="${_javaccOutputDir}/TokenMgrError.java.ignore"
     />
   </target>
-   
+
   <target name="compile" depends="javacc">
     <fail unless="boot.classpath.j2se1.7.correct"><!--
       -->The "boot.classpath.j2se1.7" property value (${boot.classpath.j2se1.7}) <!--
@@ -214,7 +214,7 @@
       -->Java 8: ${boot.classpath.j2se1.8}<!--
     --></echo>
 
-    <!-- Comment out @SuppressFBWarnings, as it causes compilation warnings in dependent Gradle projects -->    
+    <!-- Comment out @SuppressFBWarnings, as it causes compilation warnings in dependent Gradle projects -->
     <delete dir="build/src-main-java-filtered" />
     <mkdir dir="build/src-main-java-filtered" />
     <copy toDir="build/src-main-java-filtered">
@@ -232,12 +232,12 @@
     >
       <fileset dir="build/src-main-java-filtered" includes="**/*.java" />
     </replaceregexp>
-    
+
     <mkdir dir="build/classes" />
 
     <!-- Note: the "build.base" conf doesn't include optional FreeMarker dependencies. -->
     <ivy:cachepath conf="build.base" pathid="ivy.dep" />
-    <javac destdir="build/classes" deprecation="off" 
+    <javac destdir="build/classes" deprecation="off"
       debug="on" optimize="off" target="1.7" source="1.7" encoding="utf-8"
       includeantruntime="false"
       classpathref="ivy.dep"
@@ -247,7 +247,7 @@
         freemarker/ext/jsp/**,
         freemarker/ext/servlet/**,
         freemarker/cache/WebappTemplateLoader.java,
-        
+
         freemarker/ext/jython/**,
         freemarker/template/utility/JythonRuntime.java,
         freemarker/ext/ant/**"
@@ -259,14 +259,14 @@
     </javac>
 
     <ivy:cachepath conf="build.base" pathid="ivy.dep" />
-    <javac srcdir="build/src-main-java-filtered" destdir="build/classes" deprecation="off" 
+    <javac srcdir="build/src-main-java-filtered" destdir="build/classes" deprecation="off"
       debug="on" optimize="off" target="1.8" source="1.8" encoding="utf-8"
       includeantruntime="false"
       classpathref="ivy.dep"
       bootclasspath="${boot.classpath.j2se1.8}"
       includes="freemarker/core/_Java8Impl.java"
     />
-    
+
     <rmic
       base="build/classes" includes="freemarker/debug/impl/Rmi*Impl.class"
       classpathref="ivy.dep"
@@ -274,7 +274,7 @@
     />
 
     <ivy:cachepath conf="build.jsp2.0" pathid="ivy.dep.jsp2.0" />
-    <javac srcdir="build/src-main-java-filtered" destdir="build/classes" deprecation="off" 
+    <javac srcdir="build/src-main-java-filtered" destdir="build/classes" deprecation="off"
       debug="on" optimize="off" target="1.7" source="1.7" encoding="utf-8"
       includeantruntime="false"
       classpathref="ivy.dep.jsp2.0"
@@ -288,11 +288,11 @@
         freemarker/ext/jsp/FreeMarkerJspFactory21.java,
         freemarker/ext/jsp/FreeMarkerJspApplicationContext.java"
     />
-    
+
     <!-- There's no build.jsp2.0, as those classes are part of the common build subset. -->
-    
+
     <ivy:cachepath conf="build.jsp2.1" pathid="ivy.dep.jsp2.1" />
-    <javac srcdir="build/src-main-java-filtered" destdir="build/classes" deprecation="off" 
+    <javac srcdir="build/src-main-java-filtered" destdir="build/classes" deprecation="off"
       debug="on" optimize="off" target="1.7" source="1.7" encoding="utf-8"
       includeantruntime="false"
       classpathref="ivy.dep.jsp2.1"
@@ -304,7 +304,7 @@
     />
 
     <ivy:cachepath conf="build.jython2.0" pathid="ivy.dep.jython2.0" />
-    <javac srcdir="build/src-main-java-filtered" destdir="build/classes" deprecation="off" 
+    <javac srcdir="build/src-main-java-filtered" destdir="build/classes" deprecation="off"
       debug="on" optimize="off" target="1.7" source="1.7" encoding="utf-8"
       includeantruntime="false"
       classpathref="ivy.dep.jython2.0"
@@ -317,9 +317,9 @@
         freemarker/ext/jython/_Jython22VersionAdapter.java,
         freemarker/ext/jython/_Jython25VersionAdapter.java"
     />
-    
+
     <ivy:cachepath conf="build.jython2.2" pathid="ivy.dep.jython2.2" />
-    <javac srcdir="build/src-main-java-filtered" destdir="build/classes" deprecation="off" 
+    <javac srcdir="build/src-main-java-filtered" destdir="build/classes" deprecation="off"
       debug="on" optimize="off" target="1.7" source="1.7" encoding="utf-8"
       includeantruntime="false"
       classpathref="ivy.dep.jython2.2"
@@ -327,9 +327,9 @@
       includes="
         freemarker/ext/jython/_Jython22VersionAdapter.java"
     />
-    
+
     <ivy:cachepath conf="build.jython2.5" pathid="ivy.dep.jython2.5" />
-    <javac srcdir="build/src-main-java-filtered" destdir="build/classes" deprecation="off" 
+    <javac srcdir="build/src-main-java-filtered" destdir="build/classes" deprecation="off"
       debug="on" optimize="off" target="1.7" source="1.7" encoding="utf-8"
       includeantruntime="false"
       classpathref="ivy.dep.jython2.5"
@@ -337,12 +337,12 @@
       includes="
         freemarker/ext/jython/_Jython25VersionAdapter.java"
     />
-    
+
     <rmic base="build/classes" classpathref="ivy.dep"
       includes="build/src-main-java-filtered/freemarker/debug/impl/Rmi*Impl.class"
       verify="yes" stubversion="1.2"
     />
-    
+
     <copy toDir="build/classes">
       <fileset dir="src/main/resources"
         excludes="
@@ -363,9 +363,9 @@
 
   <target name="compileTest" depends="compile">
     <mkdir dir="build/test-classes" />
-  
+
     <ivy:cachepath conf="build.test" pathid="ivy.dep.build.test" />
-    <javac srcdir="src/test/java" destdir="build/test-classes" deprecation="off" 
+    <javac srcdir="src/test/java" destdir="build/test-classes" deprecation="off"
       debug="on" optimize="off" target="1.8" source="1.8" encoding="utf-8"
       includeantruntime="false"
       classpath="build/classes"
@@ -378,14 +378,14 @@
       />
     </copy>
   </target>
-   
+
    <target name="jar" depends="compile">
     <ivy:cachepath pathid="ivy.dep" conf="bnd" />
     <taskdef resource="aQute/bnd/ant/taskdef.properties"
       uri="http://www.aqute.biz/bnd"
       classpathref="ivy.dep"
     />
-  
+
     <!-- Hack: This file should be excluded, but I can't explain that to bnd. -->
     <!-- We don't have this file in 2.4.X... yet?
     <move
@@ -432,7 +432,7 @@
       </batchtest>
     </junit>
   </target>
-  
+
   <!-- ================================================================= -->
   <!-- Generate docs                                                     -->
   <!-- ================================================================= -->
@@ -467,7 +467,7 @@
         <exclude name="**/log/CommonsLoggingLoggerFactory.java" />
       </fileset>
     </copy>
-    
+
     <!-- conf="IDE": as that has to contain all depedencies -->
     <ivy:cachepath conf="IDE" pathid="ivy.dep" />
     <javadoc
@@ -496,14 +496,14 @@
   </target>
 
   <target name="javadoc" depends="_rawJavadoc, _fixJDK8JavadocCSS" description="Build the JavaDocs" />
-  
+
   <target name="_fixJDK8JavadocCSS" depends="_rawJavadoc" if="atLeastJDK8">
     <property name="file" value="build/api/stylesheet.css" />
-        
+
     <available file="${file}" property="stylesheet.available"/>
     <fail unless="stylesheet.available">CSS file not found: ${file}</fail>
     <echo>Fixing JDK 8 CSS in ${file}</echo>
-    
+
     <!-- Tell that it's modified: -->
     <replaceregexp
         file="${file}" flags="gs" encoding="utf-8"
@@ -515,7 +515,7 @@
         file="${file}" flags="gs" encoding="utf-8"
         match="@import url\('resources/fonts/dejavu.css'\);\s*" replace=""
     />
-    
+
     <!-- Font family fixes: -->
     <replaceregexp
         file="${file}" flags="gsi" encoding="utf-8"
@@ -549,7 +549,7 @@
         file="${file}" flags="gsi" encoding="utf-8"
         match="(?&lt;=[\s,:])Arial\s*,\s*Arial\b" replace="Arial"
     />
-    
+
     <!-- "Parameters:", "Returns:", "Throws:", "Since:", "See also:" etc. fixes: -->
     <property name="ddSelectorStart" value="(?:\.contentContainer\s+\.(?:details|description)|\.serializedFormContainer)\s+dl\s+dd\b.*?\{[^\}]*\b" />
     <property name="ddPropertyEnd" value="\b.+?;" />
@@ -564,11 +564,11 @@
         match="(${ddSelectorStart})font-family${ddPropertyEnd}" replace="\1"
     />
   </target>
-  
+
   <!-- ====================== -->
   <!-- Manual                 -->
   <!-- ====================== -->
-  
+
   <macrodef name="manual" uri="http://freemarker.org/util">
     <attribute name="offline" />
     <attribute name="locale" />
@@ -578,14 +578,14 @@
         uri="http://freemarker.org/docgen"
         classpathref="ivy.dep"
       />
-      
+
       <docgen:transform
         srcdir="src/manual/@{locale}" destdir="build/manual/@{locale}"
         offline="@{offline}"
       />
     </sequential>
   </macrodef>
-  
+
   <target name="manualOffline" depends="init" description="Build the Manual for offline use" >
     <u:manual offline="true" locale="en_US" />
   </target>
@@ -593,7 +593,7 @@
   <target name="manualOnline" depends="init" description="Build the Manual to be upload to the FreeMarker homepage" >
     <u:manual offline="false" locale="en_US" />
   </target>
-  
+
   <target name="manualOffline_zh_CN" depends="init" description="Build the Manual for offline use" >
     <u:manual offline="true" locale="zh_CN" />
   </target>
@@ -601,7 +601,7 @@
   <target name="manualOnline_zh_CN" depends="init" description="Build the Manual to be upload to the FreeMarker homepage" >
     <u:manual offline="false" locale="zh_CN" />
   </target>
-  
+
 
   <!-- ===================== -->
   <!-- Distribution building -->
@@ -618,7 +618,7 @@
     <antcall target="clean" />  <!-- To improve the reliability -->
     <antcall target="_dist" />
   </target>
-  
+
   <target name="_dist"
     depends="test, jar, javadoc, manualOffline"
   >
@@ -627,9 +627,9 @@
     <!-- ..................................... -->
     <!-- Binary distribution                   -->
     <!-- ..................................... -->
-    
+
     <mkdir dir="${dist.bin.dir}" />
-    
+
     <!-- Copy txt-s -->
     <copy todir="${dist.bin.dir}" includeEmptyDirs="no">
       <fileset dir="." defaultexcludes="no">
@@ -656,7 +656,7 @@
 
     <!-- Copy documentation -->
     <mkdir dir="${dist.bin.dir}/documentation" />
-    
+
     <!--
       The US English Manual is the source of any translations and thus it's the
       only one that is guaranteed to be up to date when doing the release, so we
@@ -668,7 +668,7 @@
     <copy todir="${dist.bin.dir}/documentation/_html/api" includeEmptyDirs="no">
       <fileset dir="build/api" />
     </copy>
-    
+
     <u:packageAndSignDist
         srcDir="${dist.bin.dir}/.."
         archiveNameWithoutExt="${dist.archiveBaseName}-bin"
@@ -677,7 +677,7 @@
     <!-- ..................................... -->
     <!-- Source distribution                   -->
     <!-- ..................................... -->
-    
+
     <mkdir dir="${dist.src.dir}" />
 
     <!-- Copy extensionless files: -->
@@ -694,7 +694,7 @@
       token="{version}"
       value="${version}"
     />
-    
+
     <copy todir="${dist.src.dir}" includeEmptyDirs="no">
       <fileset dir="." defaultexcludes="no">
         <exclude name="**/*.bak" />
@@ -709,7 +709,7 @@
         <include name="rat-excludes" />
       </fileset>
     </copy>
-    
+
     <u:packageAndSignDist
         srcDir="${dist.src.dir}/.."
         archiveNameWithoutExt="${dist.archiveBaseName}-src"
@@ -740,7 +740,7 @@
         <arg value="--detach-sig" />
         <arg value="${archive.gzip}" />
       </exec>
-      
+
       <echo>*** Signature verification: ***</echo>
       <exec executable="${gpgCommand}" failonerror="true">
         <arg value="--verify" />
@@ -757,12 +757,12 @@
         <equals arg1="y" arg2="${signatureGood}"/>
       </condition>
       <fail unless="signatureGood.y" message="Task aborted by user." />
-    
+
       <echo>Creating checksum file for "${archive.gzip}"...</echo>
       <checksum file="${archive.gzip}" fileext=".sha512" algorithm="SHA-512" forceOverwrite="yes" />
     </sequential>
   </macrodef>
-  
+
   <target name="maven-pom">
     <echo file="build/pom.xml"><![CDATA[<?xml version="1.0" encoding="utf-8"?>
 <!--
@@ -773,9 +773,9 @@
   to you under the Apache License, Version 2.0 (the
   "License"); you may not use this file except in compliance
   with the License.  You may obtain a copy of the License at
-  
+
     http://www.apache.org/licenses/LICENSE-2.0
-  
+
   Unless required by applicable law or agreed to in writing,
   software distributed under the License is distributed on an
   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -783,24 +783,24 @@
   specific language governing permissions and limitations
   under the License.
 -->
-    
+
 <project xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  
+
   <parent>
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>
     <version>17</version>
   </parent>
-  
+
   <groupId>${mavenGroupId}</groupId>
   <artifactId>${mavenArtifactId}</artifactId>
   <version>${mavenVersion}</version>
-  
+
   <packaging>jar</packaging>
-  
+
   <name>Apache FreeMarker</name>
   <description>
     Google App Engine compliant variation of FreeMarker.
@@ -811,15 +811,15 @@
     <name>Apache Software Foundation</name>
     <url>http://apache.org</url>
   </organization>
-  
+
   <licenses>
     <license>
       <name>Apache License, Version 2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-      <distribution>repo</distribution>      
+      <distribution>repo</distribution>
     </license>
   </licenses>
-  
+
   <scm>
     <connection>scm:git:https://git-wip-us.apache.org/repos/asf/freemarker.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/freemarker.git</developerConnection>
@@ -852,7 +852,7 @@
       <post>private@freemarker.apache.org</post>
     </mailingList>
   </mailingLists>
-  
+
   <dependencies>
     <!-- no required dependencies -->
   </dependencies>
@@ -922,7 +922,7 @@ Proceed? </input>
       <equals arg1="y" arg2="${mavenUpload.answer}"/>
     </condition>
     <fail unless="mavenUpload.yes" message="Task aborted by user." />
-    
+
 		<!-- Sign and deploy the main artifact -->
 		<exec executable="${mvnCommand}" failonerror="true">
 			<arg value="org.apache.maven.plugins:maven-gpg-plugin:1.6:sign-and-deploy-file" />
@@ -938,7 +938,7 @@ Proceed? </input>
 			<arg value="-Djavadoc=build/maven-javadoc-attachment.jar" />
       <arg value="-Pgpg" />
 		</exec>
-    
+
     <echo>*****************************************************************</echo>
     <echo>Check the above lines for any Maven errors!</echo>
     <echo>Now you need to close and maybe release the staged repo on</echo>
@@ -963,7 +963,7 @@ Proceed? </input>
   <!-- ================================================================== -->
   <!-- Dependency management                                              -->
   <!-- ================================================================== -->
-  
+
   <target name="report-deps"
     description="Creates a HTML document that summarizes the dependencies."
   >
@@ -971,15 +971,15 @@ Proceed? </input>
     <ivy:resolve />
     <ivy:report todir="build/deps-report" />
   </target>
-  
+
   <target name="ide-dependencies" depends="jar"
     description="If your IDE has no Ivy support, this generates ide-lib/*.jar for it">
     <mkdir dir="ide-dependencies" />
-    <delete includeEmptyDirs="true">  
-      <fileset dir="ide-dependencies">  
-         <include name="*/**" />  
-      </fileset>  
-    </delete>    
+    <delete includeEmptyDirs="true">
+      <fileset dir="ide-dependencies">
+         <include name="*/**" />
+      </fileset>
+    </delete>
     <ivy:retrieve conf="IDE" pattern="ide-dependencies/[artifact]-[revision].[ext]" />
 
     <!--
@@ -997,6 +997,33 @@ Proceed? </input>
       -->Do not edit the files in this directory! They are extracted from freemarker.jar as part of&#x0a;<!--
       -->the ide-dependencies Ant task, because Eclipse OSGi support expects them to be here.<!--
     --></echo>
+
+  <!--
+    Add bndtools support (bnd workspace model), which requires a bnd.bnd file to be present.
+    See https://bndtools.org/concepts.html#workspacerepositoriesproject-model for more information.
+    We copy the existing osgi.bnd to bnd.bnd and replace the variables
+    with values from this build.xml and version.properties
+    The resulting bnd.bnd in the project root is only consumed by Eclipse
+    if the bndtools plugin is installed.
+    bnd.bnd is also in .gitignore, to avoid accidental commits.
+  -->
+    <filter token="moduleOrg" value="${moduleOrg}" />
+    <filter token="moduleName" value="${moduleName}" />
+    <filter filtersfile="build/classes/freemarker/version.properties" />
+
+    <copy
+        file="osgi.bnd"
+        tofile="bnd.bnd"
+        filtering="true"
+        overwrite="true"
+    >
+      <filterchain>
+          <expandproperties />
+      </filterchain>
+    </copy>
+
+
+
   </target>
 
   <!-- ================================================================== -->
@@ -1009,8 +1036,8 @@ Proceed? </input>
       uri="antlib:org.apache.rat.anttasks"
       resource="org/apache/rat/anttasks/antlib.xml"
       classpathref="ivy.dep"
-    />  
-    
+    />
+
     <rat:report reportFile="build/rat-report-root.txt">
       <fileset dir="" excludesfile="rat-excludes" />
     </rat:report>
@@ -1024,5 +1051,5 @@ Proceed? </input>
     -->Rat reports were written into build/rat-report-*.txt<!--
     --></echo>
   </target>
-    
+
 </project>


### PR DESCRIPTION
## What

This PR is to make it possible to import freemarker in a [bndtools](https://github.com/bndtools/bnd) Eclipse project (OSGI).
See https://bndtools.org/concepts.html

This allows for easier debugging and development when you are working in OSGI project based on bndtools and you need a Freemarker source build right in your IDE for debugging purposes with your other code.

## Why

Although in the past there has been some OSGi related additions for Eclipse, those changes were for Eclipse PDE-Build and do not work if you are using bndtools. 

The main issue is that bndtools requires a file called `bnd.bnd`
There is already an `osgi.bnd`
The problem with `osgi.bnd` is that it 

a) has the wrong name and
b) contains variables likle `${versionForOsgi}` which need to be replaced with valid values which are already available during the build.

## Details

This PR adds a small addition to the `ide-dependencies` build target to create such a valid `bnd.bnd` file from the existing `osgi.bnd` Advantage is that we leave everything untouched and just create a new file which is also `.gitignored` and only be read by Eclipse IDE with bndtools plugin installed.

* This creates a `bnd.bnd` file in build for `ide-dependencies` by simply copying the existing `osgi.bnd`
* run `ant clean jar ide-dependencies` to execute this PR's changes and see the resulting `bnd.bnd` in project root
* replaces placeholder variables in the resulting `bnd.bnd`
* this exact filename is required by bndtools in the bnd workspace model
* See https://bndtools.org/concepts.html#workspacerepositoriesproject-model for more information
