### PR TITLE
Fix string comparison to avoid using the collator.

### DIFF
--- a/src/main/java/freemarker/core/EvalUtil.java
+++ b/src/main/java/freemarker/core/EvalUtil.java
@@ -276,11 +276,14 @@ class EvalUtil {
                 throw new _MiscTemplateException(defaultBlamed, env,
                         "Can't use operator \"", cmpOpToString(operator, operatorString), "\" on string values.");
             }
-            String leftString = Normalizer.normalize(
-                    EvalUtil.modelToString((TemplateScalarModel) leftValue, leftExp, env), Normalizer.Form.NFKC);
-            String rightString = Normalizer.normalize(
-                    EvalUtil.modelToString((TemplateScalarModel) rightValue, rightExp, env), Normalizer.Form.NFKC);
-            cmpResult = leftString.compareTo(rightString);
+            String leftString = EvalUtil.modelToString((TemplateScalarModel) leftValue, leftExp, env);
+            String rightString = EvalUtil.modelToString((TemplateScalarModel) rightValue, rightExp, env);
+            if (env.getConfiguration().getIncompatibleImprovements().intValue() <= _VersionInts.V_2_3_32) {
+                cmpResult = env.getCollator().compare(leftString, rightString);
+            } else {
+                cmpResult = Normalizer.normalize(leftString, Normalizer.Form.NFKC)
+                         .compareTo(Normalizer.normalize(rightString, Normalizer.Form.NFKC));
+            }
         } else if (leftValue instanceof TemplateBooleanModel && rightValue instanceof TemplateBooleanModel) {
             if (operator != CMP_OP_EQUALS && operator != CMP_OP_NOT_EQUALS) {
                 throw new _MiscTemplateException(defaultBlamed, env,

--- a/src/main/java/freemarker/core/EvalUtil.java
+++ b/src/main/java/freemarker/core/EvalUtil.java
@@ -277,8 +277,7 @@ class EvalUtil {
             }
             String leftString = EvalUtil.modelToString((TemplateScalarModel) leftValue, leftExp, env);
             String rightString = EvalUtil.modelToString((TemplateScalarModel) rightValue, rightExp, env);
-            // FIXME NBC: Don't use the Collator here. That's locale-specific, but ==/!= should not be.
-            cmpResult = env.getCollator().compare(leftString, rightString);
+            cmpResult = leftString.compareTo(rightString);
         } else if (leftValue instanceof TemplateBooleanModel && rightValue instanceof TemplateBooleanModel) {
             if (operator != CMP_OP_EQUALS && operator != CMP_OP_NOT_EQUALS) {
                 throw new _MiscTemplateException(defaultBlamed, env,

--- a/src/main/java/freemarker/core/EvalUtil.java
+++ b/src/main/java/freemarker/core/EvalUtil.java
@@ -20,6 +20,7 @@
 package freemarker.core;
 
 import java.lang.reflect.InvocationTargetException;
+import java.text.Normalizer;
 import java.util.Date;
 
 import freemarker.ext.beans.BeanModel;
@@ -275,8 +276,10 @@ class EvalUtil {
                 throw new _MiscTemplateException(defaultBlamed, env,
                         "Can't use operator \"", cmpOpToString(operator, operatorString), "\" on string values.");
             }
-            String leftString = EvalUtil.modelToString((TemplateScalarModel) leftValue, leftExp, env);
-            String rightString = EvalUtil.modelToString((TemplateScalarModel) rightValue, rightExp, env);
+            String leftString = Normalizer.normalize(
+                    EvalUtil.modelToString((TemplateScalarModel) leftValue, leftExp, env), Normalizer.Form.NFKC);
+            String rightString = Normalizer.normalize(
+                    EvalUtil.modelToString((TemplateScalarModel) rightValue, rightExp, env), Normalizer.Form.NFKC);
             cmpResult = leftString.compareTo(rightString);
         } else if (leftValue instanceof TemplateBooleanModel && rightValue instanceof TemplateBooleanModel) {
             if (operator != CMP_OP_EQUALS && operator != CMP_OP_NOT_EQUALS) {


### PR DESCRIPTION
 Benchmarking at Google has shown an up-to-1000x performance degradation from using the collator.