### PR TITLE
Add a simple mechanism for runtime debugging of templates.

### DIFF
--- a/src/main/java/freemarker/core/ListElseContainer.java
+++ b/src/main/java/freemarker/core/ListElseContainer.java
@@ -37,10 +37,10 @@ class ListElseContainer extends TemplateElement {
 
     @Override
     TemplateElement[] accept(Environment env) throws TemplateException, IOException {
-        if (!listPart.acceptWithResult(env)) {
-            return elsePart.accept(env);
+        if (listPart.acceptWithResult(env)) {
+            return null;
         }
-        return null;
+        return new TemplateElement[] { elsePart };
     }
 
     @Override

--- a/src/main/java/freemarker/core/TemplateProcessingTracer.java
+++ b/src/main/java/freemarker/core/TemplateProcessingTracer.java
@@ -37,27 +37,20 @@ import freemarker.template.utility.ObjectFactory;
 public interface TemplateProcessingTracer {
 
     /**
-     * Invoked when {@link Template.process()} starts processing the template.
-     * 
-     * @since 2.3.23
-     */
-    void start();
-
-    /**
      * Invoked by {@link Environment} whenever it starts processing a new template element. {@code
      * isLeafElement} indicates whether this element is a leaf, or whether the tracer should expect
      * to receive lower-level elements within the context of this one.
      * 
      * @since 2.3.23
      */
-    void trace(Template template, int beginColumn, int beginLine, int endColumn, int endLine,
+    void enterElement(Template template, int beginColumn, int beginLine, int endColumn, int endLine,
             boolean isLeafElement);
 
     /**
-     * Invoked when template processing is finished.
+     * Invoked by {@link Environment} whenever it completes processing a new template element.
      * 
      * @since 2.3.23
      */
-    void end();
+    void exitElement(Template template, int beginColumn, int beginLine, int endColumn, int endLine);
 
 }

--- a/src/main/java/freemarker/core/TemplateProcessingTracer.java
+++ b/src/main/java/freemarker/core/TemplateProcessingTracer.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package freemarker.core;
+
+import freemarker.ext.util.IdentityHashMap;
+import freemarker.template.Configuration;
+import freemarker.template.Template;
+import freemarker.template.TemplateDirectiveModel;
+import freemarker.template.TemplateTransformModel;
+import freemarker.template.utility.ObjectFactory;
+
+/**
+ * Run-time tracer plug-in. This may be * used to implement profiling, coverage analytis, execution tracing,
+ * and other on-the-fly debugging mechanisms.
+ * <p>
+ * Use {@link Environment#setTracer(TemplateProcessingTracer)} to configure a tracer for the current environment.
+ * 
+ * @since 2.3.33
+ */
+public interface TemplateProcessingTracer {
+
+    /**
+     * Invoked when {@link Template.process()} starts processing the template.
+     * 
+     * @since 2.3.23
+     */
+    void start();
+
+    /**
+     * Invoked by {@link Environment} whenever it starts processing a new template element. {@code
+     * isLeafElement} indicates whether this element is a leaf, or whether the tracer should expect
+     * to receive lower-level elements within the context of this one.
+     * 
+     * @since 2.3.23
+     */
+    void trace(Template template, int beginColumn, int beginLine, int endColumn, int endLine,
+            boolean isLeafElement);
+
+    /**
+     * Invoked when template processing is finished.
+     * 
+     * @since 2.3.23
+     */
+    void end();
+
+}

--- a/src/test/java/freemarker/core/TemplateProcessingTracerTest.java
+++ b/src/test/java/freemarker/core/TemplateProcessingTracerTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package freemarker.core;
+
+import static org.junit.Assert.*;
+
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+
+import freemarker.template.Configuration;
+import freemarker.template.Template;
+
+public class TemplateProcessingTracerTest {
+
+    private static final String TEMPLATE_TEXT =
+            "<#if 0 == 1>Nope.\n</#if>" +
+            "<#if 1 == 1>Yup.\n</#if>" +
+            "Always.\n" +
+            "<#list [1, 2, 3] as item>\n" +
+            "${item}<#else>\n" +
+            "Nope.\n" +
+            "</#list>\n" +
+            "<#list [] as item>\n" +
+            "${item}<#else>\n" +
+            "Yup.\n" +
+            "</#list>\n";
+
+    @Test
+    public void test() throws Exception {
+        Configuration cfg = new Configuration(Configuration.VERSION_2_3_32);
+        Template t = new Template("test.ftl", TEMPLATE_TEXT, cfg);
+        StringWriter sw = new StringWriter();
+        Tracer tracer = new Tracer();
+        Environment env = t.createProcessingEnvironment(null, sw);
+        env.setTracer(tracer);
+        env.process();
+
+        List<Integer> expected = Arrays.asList(2, 3, 5, 5, 5, 9);
+        assertEquals(expected, tracer.linesVisited);
+    }
+
+    private static class Tracer implements TemplateProcessingTracer {
+        ArrayList<Integer> linesVisited;
+
+        Tracer() {
+            linesVisited = new ArrayList<>();
+        }
+
+        public void start() {}
+        public void end() {}
+
+        public void trace(Template template, int beginColumn, int beginLine, int endColumn, int endLine,
+            boolean isLeafElement) {
+            if (isLeafElement) {
+                linesVisited.add(beginLine);
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
This PR adds a `TemplateProcessingTracer`, which can be used for runtime non-intrusive debugging of templates (e.g. collecting logs or coverage maps of executed lines, or profiling template execution performance).