### PR TITLE
FREEMARKER-214 - updating JavaCC to 7.0.12

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -155,11 +155,6 @@
     <delete dir="build/javacc-home.tmp" />
 
     <replace
-      file="${_javaccOutputDir}/FMParser.java"
-      token="private final LookaheadSuccess"
-      value="private static final LookaheadSuccess"
-    />
-    <replace
       file="${_javaccOutputDir}/FMParserConstants.java"
       token="public interface FMParserConstants"
       value="interface FMParserConstants"

--- a/ivy.xml
+++ b/ivy.xml
@@ -168,7 +168,7 @@
     
     <!-- parser -->
     
-    <dependency org="net.java.dev.javacc" name="javacc" rev="6.1.2" conf="parser->default" />
+    <dependency org="net.java.dev.javacc" name="javacc" rev="7.0.12" conf="parser->default" />
     
     <!-- bnd -->
     


### PR DESCRIPTION
FREEMARKER-214

Updating to JavaCC to 7.0.12 to avoid allocating new java.lang.Error instances and their associated stacktraces for each FMParser instance.

https://issues.apache.org/jira/browse/FREEMARKER-214
