### PR TITLE
Fix wrong link text in documentation

### DIFF
--- a/src/manual/en_US/book.xml
+++ b/src/manual/en_US/book.xml
@@ -12844,7 +12844,7 @@ grant codeBase "file:/path/to/freemarker.jar"
           </listitem>
 
           <listitem>
-            <para>c <link linkend="ref_builtin_c">for strings</link>, <link
+            <para>c <link linkend="ref_builtin_c">for numbers</link>, <link
             linkend="ref_builtin_c_boolean">for booleans</link>, <link
             linkend="ref_builtin_c_string">for strings</link></para>
           </listitem>


### PR DESCRIPTION
https://freemarker.apache.org/docs/ref_builtins_alphaidx.html contains `c for strings, for booleans, for strings`. This (hopefully) changes the text into `c for numbers, for booleans, for strings`.