### PR TITLE
Speedup ConcatenatedSequence iteration

### DIFF
--- a/src/main/java/freemarker/core/AddConcatExpression.java
+++ b/src/main/java/freemarker/core/AddConcatExpression.java
@@ -196,22 +196,29 @@ final class AddConcatExpression extends Expression {
         TemplateSequenceModel {
         private final TemplateSequenceModel left;
         private final TemplateSequenceModel right;
+        private final int leftSize;
+        private final int totalSize;
 
-        ConcatenatedSequence(TemplateSequenceModel left, TemplateSequenceModel right) {
+        ConcatenatedSequence(TemplateSequenceModel left, TemplateSequenceModel right) throws TemplateModelException {
             this.left = left;
             this.right = right;
+            // Calculate sizes only once and reuse them below
+            this.leftSize = left.size();
+            this.totalSize = leftSize + right.size();
+            
         }
 
         @Override
         public int size()
         throws TemplateModelException {
-            return left.size() + right.size();
+        	// No more expensive computations here
+            return totalSize;
         }
 
         @Override
         public TemplateModel get(int i)
         throws TemplateModelException {
-            int ls = left.size();
+            int ls = leftSize;
             return i < ls ? left.get(i) : right.get(i - ls);
         }
     }

--- a/src/main/java/freemarker/template/Configuration.java
+++ b/src/main/java/freemarker/template/Configuration.java
@@ -482,6 +482,9 @@ public class Configuration extends Configurable implements Cloneable, ParserConf
     /** FreeMarker version 2.3.32 (an {@link #Configuration(Version) incompatible improvements break-point}) */
     public static final Version VERSION_2_3_32 = new Version(2, 3, 32);
 
+    /** FreeMarker version 2.3.33 (an {@link #Configuration(Version) incompatible improvements break-point}) */
+    public static final Version VERSION_2_3_33 = new Version(2, 3, 33);
+
     /** The default of {@link #getIncompatibleImprovements()}, currently {@link #VERSION_2_3_0}. */
     public static final Version DEFAULT_INCOMPATIBLE_IMPROVEMENTS = Configuration.VERSION_2_3_0;
     /** @deprecated Use {@link #DEFAULT_INCOMPATIBLE_IMPROVEMENTS} instead. */

--- a/src/main/java/freemarker/template/_VersionInts.java
+++ b/src/main/java/freemarker/template/_VersionInts.java
@@ -46,5 +46,6 @@ public final class _VersionInts {
     public static final int V_2_3_30 = Configuration.VERSION_2_3_30.intValue();
     public static final int V_2_3_31 = Configuration.VERSION_2_3_31.intValue();
     public static final int V_2_3_32 = Configuration.VERSION_2_3_32.intValue();
+    public static final int V_2_3_33 = Configuration.VERSION_2_3_33.intValue();
     public static final int V_2_4_0 = Version.intValueFor(2, 4, 0);
 }


### PR DESCRIPTION
We managed to get improved performance for scenarios where after creating a list and then iterating over it. 

* store the size at creation time so that we avoid repeated expensive calculation in get() or size().
* this speeds up scenarios where ConcatenatedSequence are iterated like BuiltInsForSequence like ?join or <#list>

```
<#assign mylist = [] >
<#list 1..10000 as i><#assign mylist = mylist + [i+"foo"!?upper_case] /></#list>

${mylist?join(",")}

or

<#list mylist as e>
${e}
</#list>

```

Note:
After the change this code finishes in `< 1s`.  Before it almost never finished...

