### PR TITLE
[FREEMARKER-224] change Automatic-Module-Name to org.apache.freemarker

### DIFF
--- a/osgi.bnd
+++ b/osgi.bnd
@@ -63,4 +63,4 @@ Specification-Vendor: freemarker.org
 Implementation-Title: FreeMarker
 Implementation-Version: ${versionForMf}
 Implementation-Vendor: freemarker.org
-Automatic-Module-Name: freemarker
+Automatic-Module-Name: org.apache.freemarker


### PR DESCRIPTION
fixes [FREEMARKER-224](https://issues.apache.org/jira/browse/FREEMARKER-224)

As the current module name is not released yet, this is not a breaking change.
For further information and motivation, please see the issue.

This, of course, is open to discussion.
However, I strongly recommend to follow the reverse domain name system. Additionally, the is no need to have the root package and the module name match.