### PR TITLE
add .asf.yaml

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,0 +1,33 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+github:
+  description: "Apache Freemarker"
+  homepage: https://freemarker.apache.org/
+  dependabot_alerts: true
+  features:
+    wiki: false
+    issues: true
+    projects: true
+  enabled_merge_buttons:
+    squash:  false
+    merge:   true
+    rebase:  false
+  autolink_jira:
+    - FREEMARKER
+
+notifications:
+  jira_options: link label


### PR DESCRIPTION
Adding the .asf.yaml file allows control over a few things.

* Setting the project name
* Setting the project homepage
* Auto-linking issues (like FREEMARKER-224 which would automatically turn into a link after this is merged)
* Auto-linking pull requests into the correspinding JIRA issues
* Dependabot alerts (for developers with the respective karma only)
* enabling/disabling of specific merge buttons.

I am open to any changes, I would just like to add a little bit of convenience using the jira options and auto links.

We could also add labels to the github repository if wanted. 