### PR TITLE
[BUILD] sign and rat-check on CI build

### DIFF
--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -55,10 +55,21 @@ jobs:
           echo "mvnCommand=$(which mvn)" >> build.properties;
           echo "gpgCommand=$(which gpg)" >> build.properties;
 
+      - name: Create a gpg key for signing
+        shell: bash
+        run: >-
+          gpg --quick-gen-key --batch --passphrase '' github-build@apache.invalid;
+          echo "batch" >> "/home/runner/.gnupg/gpg.conf";
+          echo "pinentry-mode=loopback" >> "/home/runner/.gnupg/gpg.conf";
+
       - name: Prepare ant with ivy
         shell: bash
         run: ant download-ivy
 
       - name: Build with Ant and ivy
         shell: bash
-        run: ant ci
+        run: ant ci -Dci=true
+
+      - name: RAT check
+        shell: bash
+        run: ant rat

--- a/build.xml
+++ b/build.xml
@@ -25,6 +25,8 @@
   xmlns:bnd="http://www.aqute.biz/bnd"
   xmlns:rat="antlib:org.apache.rat.anttasks"
   xmlns:u="http://freemarker.org/util"
+  xmlns:if="ant:if"
+  xmlns:unless="ant:unless"
 >
 
   <!-- ================================================================== -->
@@ -748,11 +750,12 @@
       <input
          validargs="y,n"
          addproperty="signatureGood"
+         unless:set="ci"
       >Is the above signer the intended one for Apache releases?</input>
-      <condition property="signatureGood.y">
+      <condition property="signatureGood.y" unless:set="ci">
         <equals arg1="y" arg2="${signatureGood}"/>
       </condition>
-      <fail unless="signatureGood.y" message="Task aborted by user." />
+      <fail unless:set="ci" unless="signatureGood.y" message="Task aborted by user." />
 
       <echo>Creating checksum file for "${archive.gzip}"...</echo>
       <checksum file="${archive.gzip}" fileext=".sha512" algorithm="SHA-512" forceOverwrite="yes" />
@@ -952,7 +955,7 @@ Proceed? </input>
   </target>
 
   <target name="ci"
-  	depends="ci-setup, clean, jar, test, javadoc"
+  	depends="ci-setup, clean, _dist"
   	description="CI should invoke this task"
   />
 


### PR DESCRIPTION
@ddekany this PR enhances the CI by using the `_dist` target internally. This was made possible by skipping the interactive check when a `ci` property is present.
The way this project is set up, the RAT check can only be done when `_dist` was run, so it was now added to the workflow file as well. We could add it to the `ci` target instead, but I feel it should be separate for clarity.

Todo: 
* I did not check the non-ci version. Please do that before merging.
* Instead of using a new CI, we could check `ant.project.invoked-targets` instead for the presence of `ci`.