### PR TITLE
Create a `TemplateStringifiableModel` to enable custom `?string`

### DIFF
--- a/freemarker-core/src/main/java/freemarker/core/BuiltInsForMultipleTypes.java
+++ b/freemarker-core/src/main/java/freemarker/core/BuiltInsForMultipleTypes.java
@@ -46,6 +46,7 @@ import freemarker.template.TemplateNodeModel;
 import freemarker.template.TemplateNumberModel;
 import freemarker.template.TemplateScalarModel;
 import freemarker.template.TemplateSequenceModel;
+import freemarker.template.TemplateStringableModel;
 import freemarker.template.TemplateTransformModel;
 import freemarker.template._TemplateAPI;
 import freemarker.template._VersionInts;
@@ -730,7 +731,9 @@ class BuiltInsForMultipleTypes {
         @Override
         TemplateModel _eval(Environment env) throws TemplateException {
             TemplateModel model = target.eval(env);
-            if (model instanceof TemplateNumberModel) {
+            if (model instanceof TemplateStringableModel) {
+                return ((TemplateStringableModel) model).evalString();
+            } else if (model instanceof TemplateNumberModel) {
                 return new NumberFormatter((TemplateNumberModel) model, env);
             } else if (model instanceof TemplateDateModel) {
                 TemplateDateModel dm = (TemplateDateModel) model;

--- a/freemarker-core/src/main/java/freemarker/core/EvalUtil.java
+++ b/freemarker-core/src/main/java/freemarker/core/EvalUtil.java
@@ -34,6 +34,7 @@ import freemarker.template.TemplateModelException;
 import freemarker.template.TemplateNumberModel;
 import freemarker.template.TemplateScalarModel;
 import freemarker.template.TemplateSequenceModel;
+import freemarker.template.TemplateStringableModel;
 import freemarker.template._VersionInts;
 
 /**
@@ -476,7 +477,9 @@ class EvalUtil {
             Environment env)
             throws TemplateModelException, InvalidReferenceException, TemplateException,
                     NonStringOrTemplateOutputException, NonStringException {
-        if (tm instanceof TemplateScalarModel) {
+        if (tm instanceof TemplateStringableModel) {
+            return modelToString(((TemplateStringableModel) tm).evalString(), exp, env);
+        } else if (tm instanceof TemplateScalarModel) {
             return modelToString((TemplateScalarModel) tm, exp, env);
         } else if (tm == null) {
             if (env.isClassicCompatible()) {

--- a/freemarker-core/src/main/java/freemarker/template/TemplateStringableModel.java
+++ b/freemarker-core/src/main/java/freemarker/template/TemplateStringableModel.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package freemarker.template;
+
+import freemarker.core.TemplateMarkupOutputModel;
+
+/**
+ * Data type that supports the {@code ?string} built-in.
+ */
+public interface TemplateStringableModel extends TemplateModel {
+
+    /**
+     * Returns a string representation of the current value.
+     */
+    public TemplateScalarModel evalString() throws TemplateModelException;
+
+}

--- a/freemarker-core/src/test/java/freemarker/core/StringifiableTest.java
+++ b/freemarker-core/src/test/java/freemarker/core/StringifiableTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package freemarker.core;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import freemarker.template.Configuration;
+import freemarker.template.SimpleScalar;
+import freemarker.template.TemplateException;
+import freemarker.template.TemplateModel;
+import freemarker.template.TemplateModelException;
+import freemarker.template.TemplateScalarModel;
+import freemarker.template.TemplateStringableModel;
+import freemarker.test.TemplateTest;
+
+public class StringifiableTest extends TemplateTest {
+    
+    private static class Stringable implements TemplateStringableModel {
+
+        private final String s;
+
+        Stringable(String s) { this.s = s; }
+
+        @Override public TemplateScalarModel evalString() {
+            return new SimpleScalar("<" + s + ">");
+        }
+    }
+
+    @Test
+    public void testStringifiable() throws IOException, TemplateException {
+        assertOutput("${zz}", "<zz>");
+        assertOutput("${zz?string}", "<zz>");
+        assertErrorContains("${yy}", "misc_template_model");
+    }
+
+    @Before
+    public void setup() throws TemplateModelException {
+        Configuration cfg = getConfiguration();
+        
+        addToDataModel("zz", new Stringable("zz"));
+        addToDataModel("yy", new TemplateModel() {});
+    }
+
+}


### PR DESCRIPTION
in `TemplateModel` subclasses