### PR TITLE
use StandardCharsets instead of string

### DIFF
--- a/freemarker-core/src/main/java/freemarker/debug/DebuggerClient.java
+++ b/freemarker-core/src/main/java/freemarker/debug/DebuggerClient.java
@@ -24,6 +24,7 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.net.InetAddress;
 import java.net.Socket;
+import java.nio.charset.StandardCharsets;
 import java.rmi.RemoteException;
 import java.rmi.server.RemoteObject;
 import java.security.MessageDigest;
@@ -71,7 +72,7 @@ public class DebuggerClient {
                 }
                 byte[] challenge = (byte[]) in.readObject();
                 MessageDigest md = MessageDigest.getInstance("SHA");
-                md.update(password.getBytes("UTF-8"));
+                md.update(password.getBytes(StandardCharsets.UTF_8));
                 md.update(challenge);
                 out.writeObject(md.digest());
                 return new LocalDebuggerProxy((Debugger) in.readObject());

--- a/freemarker-core/src/main/java/freemarker/debug/impl/DebuggerServer.java
+++ b/freemarker-core/src/main/java/freemarker/debug/impl/DebuggerServer.java
@@ -23,9 +23,9 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
-import java.io.UnsupportedEncodingException;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.SecureRandom;
 import java.util.Arrays;
@@ -34,7 +34,6 @@ import java.util.Random;
 import freemarker.debug.Debugger;
 import freemarker.log.Logger;
 import freemarker.template.utility.SecurityUtilities;
-import freemarker.template.utility.UndeclaredThrowableException;
 
 /**
  */
@@ -51,11 +50,8 @@ class DebuggerServer {
     
     public DebuggerServer(Serializable debuggerStub) {
         port = SecurityUtilities.getSystemProperty("freemarker.debug.port", Debugger.DEFAULT_PORT).intValue();
-        try {
-            password = SecurityUtilities.getSystemProperty("freemarker.debug.password", "").getBytes("UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            throw new UndeclaredThrowableException(e);
-        }
+        password = SecurityUtilities.getSystemProperty("freemarker.debug.password", "")
+                .getBytes(StandardCharsets.UTF_8);
         this.debuggerStub = debuggerStub;
     }
     

--- a/freemarker-core/src/main/java/freemarker/ext/beans/DefaultMemberAccessPolicy.java
+++ b/freemarker-core/src/main/java/freemarker/ext/beans/DefaultMemberAccessPolicy.java
@@ -26,6 +26,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -162,7 +163,7 @@ public final class DefaultMemberAccessPolicy implements MemberAccessPolicy {
         try (BufferedReader reader = new BufferedReader(
                 new InputStreamReader(
                         DefaultMemberAccessPolicy.class.getResourceAsStream("DefaultMemberAccessPolicy-rules"),
-                        "UTF-8"))) {
+                        StandardCharsets.UTF_8))) {
             String line;
             while ((line = reader.readLine()) != null) {
                 whitelist.add(line);

--- a/freemarker-core/src/test/java/freemarker/core/TemplateConfigurationWithTemplateCacheTest.java
+++ b/freemarker-core/src/test/java/freemarker/core/TemplateConfigurationWithTemplateCacheTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.*;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 
 import org.junit.Test;
@@ -71,7 +72,7 @@ public class TemplateConfigurationWithTemplateCacheTest {
         {
             Template t = cfg.getTemplate("default.ftl", "iso-8859-5");
             assertEquals("iso-8859-5", t.getEncoding());
-            assertEquals(new String(TEXT_WITH_ACCENTS.getBytes("iso-8859-1"), "iso-8859-5"),
+            assertEquals(new String(TEXT_WITH_ACCENTS.getBytes(StandardCharsets.ISO_8859_1), "iso-8859-5"),
                     getTemplateOutput(t));
         }
         {
@@ -100,11 +101,11 @@ public class TemplateConfigurationWithTemplateCacheTest {
                         + "<#include 'utf16.ftl' encoding='iso-8859-5'>"
                         + "<#include 'default.ftl' encoding='iso-8859-5'>"
                         + "<#include 'utf8-latin2.ftl' encoding='iso-8859-5'>"
-                ).getBytes("iso-8859-1"));
+                ).getBytes(StandardCharsets.ISO_8859_1));
         assertEquals(
                 TEXT_WITH_ACCENTS + TEXT_WITH_ACCENTS + TEXT_WITH_ACCENTS + TEXT_WITH_ACCENTS
                 + TEXT_WITH_ACCENTS + TEXT_WITH_ACCENTS
-                + new String(TEXT_WITH_ACCENTS.getBytes("iso-8859-1"), "iso-8859-5")
+                + new String(TEXT_WITH_ACCENTS.getBytes(StandardCharsets.ISO_8859_1), "iso-8859-5")
                 + TEXT_WITH_ACCENTS,
                 getTemplateOutput(cfg.getTemplate("main.ftl")));
     }
@@ -301,8 +302,8 @@ public class TemplateConfigurationWithTemplateCacheTest {
         cfg.setLocale(Locale.US);
         
         ByteArrayTemplateLoader tl = new ByteArrayTemplateLoader();
-        tl.putTemplate("utf8.ftl", TEXT_WITH_ACCENTS.getBytes("utf-8"));
-        tl.putTemplate("utf16.ftl", TEXT_WITH_ACCENTS.getBytes("utf-16"));
+        tl.putTemplate("utf8.ftl", TEXT_WITH_ACCENTS.getBytes(StandardCharsets.UTF_8));
+        tl.putTemplate("utf16.ftl", TEXT_WITH_ACCENTS.getBytes(StandardCharsets.UTF_16));
         tl.putTemplate("default.ftl", TEXT_WITH_ACCENTS.getBytes("iso-8859-2"));
         tl.putTemplate("utf8-latin2.ftl",
                 ("<#ftl encoding='iso-8859-2'>" + TEXT_WITH_ACCENTS).getBytes("iso-8859-2"));

--- a/freemarker-javax-servlet/src/test/java/freemarker/test/servlet/WebAppTestCase.java
+++ b/freemarker-javax-servlet/src/test/java/freemarker/test/servlet/WebAppTestCase.java
@@ -27,6 +27,7 @@ import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -128,7 +129,7 @@ public class WebAppTestCase {
             final String content;
             if (responseCode == 200) {
                 try (InputStream in = httpCon.getInputStream()) {
-                    content = IOUtils.toString(in, "UTF-8");
+                    content = IOUtils.toString(in, StandardCharsets.UTF_8);
                 }
             } else {
                 content = null;
@@ -187,7 +188,8 @@ public class WebAppTestCase {
             ClassPathResource cpResource = findWebAppDirectoryResource(webAppName);
             try (InputStream in = cpResource.resolverClass.getResourceAsStream(
                     cpResource.path + EXPECTED_DIR + expectedFileName)) {
-                expected = TestUtil.removeTxtCopyrightComment(normalizeWS(IOUtils.toString(in, "utf-8"), compressWS));
+                expected = TestUtil.removeTxtCopyrightComment(normalizeWS(IOUtils.toString(in, StandardCharsets.UTF_8),
+                        compressWS));
             }
         }
         assertEquals(maskIgnored(expected, ignoredParts), maskIgnored(actual, ignoredParts));

--- a/freemarker-test-utils/src/main/java/freemarker/core/ASTPrinter.java
+++ b/freemarker-test-utils/src/main/java/freemarker/core/ASTPrinter.java
@@ -34,6 +34,7 @@ import java.nio.ByteBuffer;
 import java.nio.charset.CharacterCodingException;
 import java.nio.charset.Charset;
 import java.nio.charset.CodingErrorAction;
+import java.nio.charset.StandardCharsets;
 import java.util.Enumeration;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
@@ -179,9 +180,9 @@ public class ASTPrinter {
         }
         
         try {
-            return decode(buffer, Charset.forName("UTF-8"));
+            return decode(buffer, StandardCharsets.UTF_8);
         } catch (CharacterCodingException e) {
-            return decode(buffer, Charset.forName("ISO-8859-1"));
+            return decode(buffer, StandardCharsets.ISO_8859_1);
         }
     }
 

--- a/freemarker-test-utils/src/main/java/freemarker/test/ResourcesExtractor.java
+++ b/freemarker-test-utils/src/main/java/freemarker/test/ResourcesExtractor.java
@@ -26,6 +26,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.jar.JarOutputStream;
 import java.util.zip.ZipEntry;
 
@@ -101,7 +102,7 @@ public final class ResourcesExtractor {
             deleteDstRootDir = !dstRootDir.exists();
         }
         try {
-            try (BufferedReader contR = new BufferedReader(new InputStreamReader(contIn, "UTF-8"))) {
+            try (BufferedReader contR = new BufferedReader(new InputStreamReader(contIn, StandardCharsets.UTF_8))) {
                 String contLine;
                 while ((contLine = contR.readLine()) != null) {
                     processLine(contLine, resolverClass, srcDirResourcePath, dstRootDir, contResource);

--- a/freemarker-test-utils/src/main/java/freemarker/test/TemplateTest.java
+++ b/freemarker-test-utils/src/main/java/freemarker/test/TemplateTest.java
@@ -118,7 +118,7 @@ public abstract class TemplateTest {
                 throw new IOException("Reference output resource not found: " + this.getClass() + ", " + resName);
             }
             try {
-                expectedOut = TestUtil.removeTxtCopyrightComment(IOUtils.toString(in, "utf-8"));
+                expectedOut = TestUtil.removeTxtCopyrightComment(IOUtils.toString(in, StandardCharsets.UTF_8));
             } finally {
                 in.close();
             }

--- a/freemarker-test-utils/src/main/java/freemarker/test/utility/FileTestCase.java
+++ b/freemarker-test-utils/src/main/java/freemarker/test/utility/FileTestCase.java
@@ -32,6 +32,7 @@ import java.io.Writer;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
@@ -108,7 +109,7 @@ public abstract class FileTestCase extends TestCase {
     }
 
     private void saveString(File actualFile, String actualContents) throws IOException {
-        try (Writer w = new OutputStreamWriter(new FileOutputStream(actualFile), "UTF-8")) {
+        try (Writer w = new OutputStreamWriter(new FileOutputStream(actualFile), StandardCharsets.UTF_8)) {
             w.write(actualContents);
         }
     }


### PR DESCRIPTION
Since Java 7 `StandardCharsets` can be used for standard charsets. It prevents the unnecessary lookup of the charset and in addition no  `UnsupportedEncodingException` can be thrown.