### PR TITLE
Creating multi release jar

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ That's because different parts of the source code target different Java versions
 and Gradle requires the exact JDK version (not higher) for each.
 
 Be sure that your default Java version (which Gradle should use automatically) is at
-least 16!
+least 17!
 
 If you are building from the official source *release* (not from source that you
 got from Git), `gradle/wrapper/gradle-wrapper.jar` is missing from that, and you

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,14 +20,14 @@
 import java.io.FileOutputStream
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
-import java.util.*
+import java.util.Properties
 import java.util.stream.Collectors
 
 plugins {
     `freemarker-root`
     `maven-publish`
     signing
-    id("biz.aQute.bnd.builder") version "6.1.0"
+    id("biz.aQute.bnd.builder") version "7.0.0"
     id("eclipse")
 }
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -25,5 +25,8 @@ dependencies {
     implementation(gradleApi())
 
     implementation("org.apache.freemarker.docgen:freemarker-docgen-core:0.0.2-SNAPSHOT")
-    implementation("org.nosphere.apache:creadur-rat-gradle:0.7.0")
+    implementation("org.nosphere.apache:creadur-rat-gradle:0.8.1")
+    // Xalan dependencies are required by rat even though it does not declare a dependency on them.
+    implementation("xalan:xalan:2.7.3")
+    implementation("xalan:serializer:2.7.3")
 }

--- a/buildSrc/src/main/kotlin/freemarker/build/FreemarkerRootPlugin.kt
+++ b/buildSrc/src/main/kotlin/freemarker/build/FreemarkerRootPlugin.kt
@@ -28,7 +28,12 @@ import org.gradle.api.publish.maven.tasks.AbstractPublishToMaven
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.bundling.Jar
 import org.gradle.jvm.toolchain.JavaLanguageVersion
-import org.gradle.kotlin.dsl.*
+import org.gradle.kotlin.dsl.attributes
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.filter
+import org.gradle.kotlin.dsl.named
+import org.gradle.kotlin.dsl.the
+import org.gradle.kotlin.dsl.withType
 import org.gradle.language.base.plugins.LifecycleBasePlugin
 import org.gradle.language.jvm.tasks.ProcessResources
 
@@ -66,6 +71,9 @@ open class FreemarkerRootPlugin : Plugin<Project> {
 
                 named<Jar>(mainSourceSet.sourcesJarTaskName) {
                     from(resourceTemplatesDir)
+                    manifest.attributes(
+                        "Multi-Release" to "true"
+                    )
                 }
 
                 withType<org.nosphere.apache.rat.RatTask>() {


### PR DESCRIPTION
The tests tasks were not touched at all. So, they do not depend on the jar. If such tasks are needed, then I think new test tasks should be added as opposed adjusting the current test tasks. This is to avoid confusing IDEs (and a considerable complications), also it would make more sense conceptually that then there would be a combined test task depending on the jar for each java version (and the tasks wouldn't be directly tied to source sets).