### PR TITLE
Add distinct, distinct_by built-ins for sequence

### DIFF
--- a/freemarker-core/src/main/java/freemarker/core/BuiltIn.java
+++ b/freemarker-core/src/main/java/freemarker/core/BuiltIn.java
@@ -85,7 +85,7 @@ abstract class BuiltIn extends Expression implements Cloneable {
 
     static final Set<String> CAMEL_CASE_NAMES = new TreeSet<>();
     static final Set<String> SNAKE_CASE_NAMES = new TreeSet<>();
-    static final int NUMBER_OF_BIS = 302;
+    static final int NUMBER_OF_BIS = 305;
     static final HashMap<String, BuiltIn> BUILT_INS_BY_NAME = new HashMap<>(NUMBER_OF_BIS * 3 / 2 + 1, 1f);
 
     static final String BI_NAME_SNAKE_CASE_WITH_ARGS = "with_args";
@@ -116,6 +116,8 @@ abstract class BuiltIn extends Expression implements Cloneable {
         putBI("datetime", new BuiltInsForMultipleTypes.dateBI(TemplateDateModel.DATETIME));
         putBI("datetime_if_unknown", "datetimeIfUnknown", new BuiltInsForDates.dateType_if_unknownBI(TemplateDateModel.DATETIME));
         putBI("default", new BuiltInsForExistenceHandling.defaultBI());
+        putBI("distinct", new BuiltInsForSequences.distinctBI());
+        putBI("distinct_by", "distinctBy", new BuiltInsForSequences.distinctByBI());
         putBI("double", new doubleBI());
         putBI("drop_while", "dropWhile", new BuiltInsForSequences.drop_whileBI());
         putBI("empty_to_null", "emptyToNull", new BuiltInsForExistenceHandling.empty_to_nullBI());

--- a/freemarker-core/src/test/java/freemarker/core/DistinctBiTest.java
+++ b/freemarker-core/src/test/java/freemarker/core/DistinctBiTest.java
@@ -1,0 +1,196 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package freemarker.core;
+
+import static freemarker.core.Configurable.*;
+
+import java.io.IOException;
+import java.sql.Timestamp;
+import java.util.List;
+
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableList;
+
+import freemarker.template.Configuration;
+import freemarker.template.TemplateException;
+import freemarker.test.TemplateTest;
+
+public class DistinctBiTest extends TemplateTest {
+
+    private static final List<TestParam> TEST_DISTINCT_PARAMS = ImmutableList.of(
+            new TestParam(ImmutableList.of("a", "b", "c", "a", "c", "d"), "a, b, c, d"),
+            new TestParam(ImmutableList.of(1, 2, 3, 1, 5), "1, 2, 3, 5"),
+            new TestParam(ImmutableList.of(new Timestamp(0), new Timestamp(1000), new Timestamp(123000),
+                    new Timestamp(5000),
+                    new Timestamp(123000)),
+                    "1970-01-01 01:00:00, 1970-01-01 01:00:01, 1970-01-01 01:02:03, 1970-01-01 01:00:05"),
+            new TestParam(ImmutableList.of(), ""),
+            new TestParam(ImmutableList.of("x"), "x")
+    );
+
+    private static final List<TestParam> TEST_DISTINCT_BY_PARAMS;
+
+    static {
+        ImmutableList<TestBean> beans = ImmutableList.of(
+                new TestBean(1, "name1", 13, false, new Timestamp(1000)),
+                new TestBean(2, "name2", 10, false, new Timestamp(2000)),
+                new TestBean(3, "name2", 10, false, new Timestamp(3000)),
+                new TestBean(4, "name2", 25, true, new Timestamp(2000))
+        );
+        TEST_DISTINCT_BY_PARAMS = ImmutableList.of(
+                new TestParam(beans, "name", "1, 2", "4, 1"),
+                new TestParam(beans, "age", "1, 2, 4", "4, 3, 1"),
+                new TestParam(beans, "adult", "1, 4", "4, 3"),
+                new TestParam(beans, "birthday", "1, 2, 3", "4, 3, 1"))
+        ;
+    }
+
+    @Override
+    protected Configuration createConfiguration() throws Exception {
+        Configuration configuration = super.createConfiguration();
+        configuration.setDateTimeFormat("YYYY-MM-dd HH:mm:ss");
+        configuration.setBooleanFormat(BOOLEAN_FORMAT_LEGACY_DEFAULT);
+        return configuration;
+    }
+
+    @Test
+    public void testDistinct() throws TemplateException, IOException {
+        for (TestParam testParam : TEST_DISTINCT_PARAMS) {
+            addToDataModel("xs", testParam.list);
+            assertOutput(
+                    "<#list xs?distinct as x>${x}<#sep>, </#list>",
+                    testParam.result);
+            assertOutput(
+                    "<#assign fxs = xs?distinct>" +
+                            "${fxs?join(', ')}",
+                    testParam.result);
+        }
+    }
+
+    @Test
+    public void testDistinctBy() throws TemplateException, IOException {
+        for (TestParam testParam : TEST_DISTINCT_BY_PARAMS) {
+            addToDataModel("xs", testParam.list);
+            assertOutput(
+                    "<#list xs?distinct_by('" + testParam.field + "') as x>${x.id}<#sep>, </#list>",
+                    testParam.result);
+            assertOutput(
+                    "<#assign fxs = xs?distinct_by('" + testParam.field + "')>" +
+                            "${fxs?map(i -> i.id)?join(', ')}",
+                    testParam.result);
+
+        }
+    }
+
+    @Test
+    public void testDistinctByReverse() throws TemplateException, IOException {
+        for (TestParam testParam : TEST_DISTINCT_BY_PARAMS) {
+            addToDataModel("xs", testParam.list);
+            assertOutput(
+                    "<#list xs?reverse?distinct_by('" + testParam.field + "') as x>${x.id}<#sep>, </#list>",
+                    testParam.reverseResult);
+            assertOutput(
+                    "<#assign fxs = xs?reverse?distinct_by('" + testParam.field + "')>" +
+                            "${fxs?map(i -> i.id)?join(', ')}",
+                    testParam.reverseResult);
+
+        }
+    }
+
+    private static class TestParam {
+        private final List<?> list;
+
+        private String field;
+
+        private final String result;
+
+        private String reverseResult;
+
+        public TestParam(List<?> list, String result) {
+            this.list = list;
+            this.result = result;
+        }
+
+        public TestParam(List<?> list, String field, String result, String reverseResult) {
+            this.list = list;
+            this.field = field;
+            this.result = result;
+            this.reverseResult = reverseResult;
+        }
+    }
+
+    public static class TestBean {
+
+        private final int id;
+
+        private final String name;
+
+        private final int age;
+
+        private final boolean adult;
+
+        private final Timestamp birthday;
+
+        public TestBean(int id, String name, int age, boolean adult, Timestamp birthday) {
+            this.id = id;
+            this.name = name;
+            this.age = age;
+            this.adult = adult;
+            this.birthday = birthday;
+        }
+
+
+        public int getId() {
+            return id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public int getAge() {
+            return age;
+        }
+
+        public boolean isAdult() {
+            return adult;
+        }
+
+        public Timestamp getBirthday() {
+            return birthday;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            return obj instanceof TestBean
+                    && name.equals(((TestBean) obj).name)
+                    && age == ((TestBean) obj).age
+                    && adult == ((TestBean) obj).adult
+                    && birthday.equals(((TestBean) obj).birthday);
+        }
+
+        @Override
+        public String toString() {
+            return id + "";
+        }
+    }
+
+}

--- a/freemarker-jython25/src/test/resources/freemarker/test/templatesuite/expected/sequence-builtins.txt
+++ b/freemarker-jython25/src/test/resources/freemarker/test/templatesuite/expected/sequence-builtins.txt
@@ -402,3 +402,99 @@ Misc
 
 First of set 1: a
 First of set 2: a
+
+distinct scalars:
+----------------
+
+String distinct:
+- apple
+- banana
+- orange
+
+First: apple
+Last: orange
+Size 3
+
+Numerical distinct:
+- 123
+- 5
+- -324
+- -34
+- 0.11
+- 0
+- 111
+- 0.11
+- 123
+
+First: 123
+Last: 123
+Size 9
+
+Date/time distinct:
+- 08:05
+- 18:00
+- 06:05
+
+Boolean distinct:
+- true
+- false
+
+
+Distinct hashes:
+---------------
+
+Distinct by name:
+- 1
+- 2
+
+Distinct by name reverse:
+- 4
+- 1
+
+Distinct by age:
+- 1
+- 2
+- 4
+
+Distinct by age reverse:
+- 4
+- 3
+- 1
+
+Distinct by adult:
+- 1
+- 4
+
+Distinct by adult reverse:
+- 4
+- 3
+
+Distinct by birthday:
+- 1
+- 2
+- 3
+
+Distinct by birthday reverse:
+- 4
+- 3
+- 1
+
+Distinct by a.x.v:
+- 1
+- 2
+- 4
+
+Distinct by a.x.v reverse:
+- 4
+- 3
+- 1
+
+Distinct by a.y, which is a date:
+- 1
+- 3
+- 4
+
+Distinct by a.y reverse, which is a date:
+- 4
+- 3
+- 2

--- a/freemarker-jython25/src/test/resources/freemarker/test/templatesuite/templates/sequence-builtins.ftl
+++ b/freemarker-jython25/src/test/resources/freemarker/test/templatesuite/templates/sequence-builtins.ftl
@@ -359,3 +359,121 @@ Misc
 
 First of set 1: ${abcSet?first}
 First of set 2: ${abcSetNonSeq?first}
+
+distinct scalars:
+----------------
+
+String distinct:
+<#assign ls = ["apple", "apple", "banana", "apple", "orange"]?distinct>
+<#list ls as i>
+- ${i}
+</#list>
+
+First: ${ls?first}
+Last: ${ls?last}
+Size ${ls?size}
+
+Numerical distinct:
+<#assign ls = [123?byte, 5, -324, -34?float, 0.11, 0, 111?int, 0.11?double, 123, 5]?distinct>
+<#list ls as i>
+- ${i}
+</#list>
+
+First: ${ls?first}
+Last: ${ls?last}
+Size ${ls?size}
+
+Date/time distinct:
+<#assign x = [
+'08:05'?time('HH:mm'),
+'18:00'?time('HH:mm'),
+'06:05'?time('HH:mm'),
+'08:05'?time('HH:mm')]>
+<#list x?distinct as i>
+- ${i?string('HH:mm')}
+</#list>
+
+Boolean distinct:
+<#assign x = [
+true,
+false,
+false,
+true]>
+<#list x?distinct as i>
+- ${i}
+</#list>
+
+
+Distinct hashes:
+---------------
+
+<#assign ls = [
+{"id": 1, "name": "name1", "age": 13, "adult": false, "birthday": '2024-01-01'?date('yyyy-MM-dd')},
+{"id": 2, "name": "name2", "age": 10, "adult": false, "birthday": '2024-02-01'?date('yyyy-MM-dd')},
+{"id": 3, "name": "name2", "age": 10, "adult": false, "birthday": '2024-03-01'?date('yyyy-MM-dd')},
+{"id": 4, "name": "name2", "age": 25, "adult": true,  "birthday": '2024-02-01'?date('yyyy-MM-dd')}
+]>
+Distinct by name:
+<#list ls?distinct_by("name") as i>
+- ${i.id}
+</#list>
+
+Distinct by name reverse:
+<#list ls?reverse?distinct_by("name") as i>
+- ${i.id}
+</#list>
+
+Distinct by age:
+<#list ls?distinct_by("age") as i>
+- ${i.id}
+</#list>
+
+Distinct by age reverse:
+<#list ls?reverse?distinct_by("age") as i>
+- ${i.id}
+</#list>
+
+Distinct by adult:
+<#list ls?distinct_by("adult") as i>
+- ${i.id}
+</#list>
+
+Distinct by adult reverse:
+<#list ls?reverse?distinct_by("adult") as i>
+- ${i.id}
+</#list>
+
+Distinct by birthday:
+<#list ls?distinct_by("birthday") as i>
+- ${i.id}
+</#list>
+
+Distinct by birthday reverse:
+<#list ls?reverse?distinct_by("birthday") as i>
+- ${i.id}
+</#list>
+
+<#assign x = [
+{"id": "1", "a": {"x": {"v": "xxxx", "w": "asd"}, "y": '1998-02-20'?date('yyyy-MM-dd')}},
+{"id": "2", "a": {"x": {"v": "xx", "w": "asd"}, "y": '1998-02-20'?date('yyyy-MM-dd')}},
+{"id": "3", "a": {"x": {"v": "xx", "w": "asd"}, "y": '1999-04-20'?date('yyyy-MM-dd')}},
+{"id": "4", "a": {"x": {"v": "xxx", "w": "asd"}, "y": '1999-04-19'?date('yyyy-MM-dd')}}]>
+Distinct by a.x.v:
+<#list x?distinct_by(['a', 'x', 'v']) as i>
+- ${i.id}
+</#list>
+
+Distinct by a.x.v reverse:
+<#list x?reverse?distinct_by(['a', 'x', 'v']) as i>
+- ${i.id}
+</#list>
+
+Distinct by a.y, which is a date:
+<#list x?distinct_by(['a', 'y']) as i>
+- ${i.id}
+</#list>
+
+Distinct by a.y reverse, which is a date:
+<#list x?reverse?distinct_by(['a', 'y']) as i>
+- ${i.id}
+</#list>

--- a/freemarker-manual/src/main/docgen/en_US/book.xml
+++ b/freemarker-manual/src/main/docgen/en_US/book.xml
@@ -12941,6 +12941,14 @@ grant codeBase "file:/path/to/freemarker.jar"
             linkend="ref_builtin_date_if_unknown">datetime_if_unknown</link></para>
           </listitem>
 
+            <listitem>
+                <para><link linkend="ref_builtin_distinct">distinct</link></para>
+            </listitem>
+
+            <listitem>
+                <para><link linkend="ref_builtin_distinct_by">distinct_by</link></para>
+            </listitem>
+
           <listitem>
             <para><link linkend="ref_builtin_numType">double</link></para>
           </listitem>
@@ -18967,6 +18975,123 @@ Filer for positives:
           <para>See also: <link
           linkend="ref_builtin_drop_while"><literal>drop_while</literal>
           built-in</link></para>
+        </section>
+
+        <section xml:id="ref_builtin_distinct">
+          <title>distinct</title>
+
+          <indexterm>
+            <primary>distinct built-in</primary>
+          </indexterm>
+
+          <indexterm>
+            <primary>sequence</primary>
+
+            <secondary>distinct</secondary>
+          </indexterm>
+
+          <para>Returns the sequence consisting of the distinct elements,
+            retaining the first accessed element. (For
+            retaining the last accessed element use <link linkend="ref_builtin_reverse">
+              <literal>reverse</literal> built
+              in</link> and then use this.) This will work only if all sub variables are strings,
+            or if all sub variables are numbers, or if all sub variables are date
+            values (date, time, or date+time), or if all sub variables are
+            booleans. If the sub variables are numbers, it uses
+            equals for distinct (<literal>123?float</literal> and <literal>123?byte</literal>
+            are not the same). For
+            example:</para>
+
+          <programlisting role="template">&lt;#assign ls = [1, 2?byte, 1, 2?float, 10]?distinct&gt;
+&lt;#list ls as i&gt;${i} &lt;/#list&gt;</programlisting>
+
+          <para>will print:</para>
+
+          <programlisting role="output">1 2 2 10</programlisting>
+        </section>
+
+        <section xml:id="ref_builtin_distinct_by">
+          <title>distinct_by</title>
+
+          <indexterm>
+            <primary>distinct_by built-in</primary>
+          </indexterm>
+
+          <indexterm>
+            <primary>sequence</primary>
+
+            <secondary>distinct_by</secondary>
+          </indexterm>
+
+          <para>Returns the sequence consisting of the distinct elements by the given hash
+            subvariable, retaining the first accessed element. (For
+            retaining the last accessed element use <link linkend="ref_builtin_reverse"><literal>
+              reverse</literal> built
+              in</link> and then use this.)  The rules are the same as the
+            <link linkend="ref_builtin_distinct"><literal>distinct</literal> built in</link>,
+            except that the sub
+            variables of the sequence must be hashes, and you have to
+            give the name of a hash subvariable that will decide the order. For example:</para>
+
+          <programlisting role="template">&lt;#assign ls = [
+{"id": 1, "name": "name1", "age": 13, "adult": false, "birthday": '2024-01-01'?date('yyyy-MM-dd')},
+{"id": 2, "name": "name2", "age": 10, "adult": false, "birthday": '2024-02-01'?date('yyyy-MM-dd')},
+{"id": 3, "name": "name2", "age": 10, "adult": false, "birthday": '2024-03-01'?date('yyyy-MM-dd')},
+{"id": 4, "name": "name2", "age": 25, "adult": true,  "birthday": '2024-02-01'?date('yyyy-MM-dd')}
+]&gt;
+Distinct by name:
+&lt;#list ls?distinct_by("name") as i&gt;
+- ${i.id}
+&lt;/#list&gt;
+
+Distinct by name reverse:
+&lt;#list ls?reverse?distinct_by("name") as i&gt;
+- ${i.id}
+&lt;/#list&gt;</programlisting>
+
+          <para>will print:</para>
+
+          <programlisting role="output">Distinct by name:
+- 1
+- 2
+
+Distinct by name reverse:
+- 4
+- 1</programlisting>
+
+          <para>If the subvariable that you want to use for the distinct is on a deeper level (that
+            is, if it is a
+          subvariable of a subvariable and so on), then you can use a sequence as parameter, that
+            specifies the
+          names of the sub variables that lead down to the desired subvariable. For example:</para>
+
+          <programlisting role="template">&lt;#assign x = [
+  {"id": "1", "a": {"x": {"v": "xxxx", "w": "asd"}, "y": '1998-02-20'?date('yyyy-MM-dd')}},
+  {"id": "2", "a": {"x": {"v": "xx", "w": "asd"}, "y": '1998-02-20'?date('yyyy-MM-dd')}},
+  {"id": "3", "a": {"x": {"v": "xx", "w": "asd"}, "y": '1999-04-20'?date('yyyy-MM-dd')}},
+  {"id": "4", "a": {"x": {"v": "xxx", "w": "asd"}, "y": '1999-04-19'?date('yyyy-MM-dd')}}
+]&gt;
+Distinct by a.x.v:
+&lt;#list x?distinct_by(['a', 'x', 'v']) as i&gt;
+- ${i.id}
+&lt;/#list&gt;
+
+Distinct by a.x.v reverse:
+&lt;#list x?reverse?distinct_by(['a', 'x', 'v']) as i&gt;
+- ${i.id}
+&lt;/#list&gt;</programlisting>
+
+          <para>will print:</para>
+
+          <programlisting role="output">Distinct by a.x.v:
+- 1
+- 2
+- 4
+
+Distinct by a.x.v reverse:
+- 4
+- 3
+- 1</programlisting>
         </section>
       </section>
 


### PR DESCRIPTION
**Add distinct, distinct_by built-ins for sequence which sub variable rules same as sort/sort_by.**

**Why?**
- Data array with simple element type(string, number, boolean, date) often require deduplication，but there is no built-in for sequence deduplication. At present, it can only be achieved through cumbersome way such as the following:
```freemarker
<!-- sort first -->
<#assign checkImportList = checkImport?split("\n")?sort>
<!-- compare with prev item -->
<#list checkImportList as check>
    <#if check != "">
        <#if check?index <= 0 || check != checkImportList[check?index - 1]>
${check}
        </#if>
    </#if>
</#list>
```
and original order of elements discarded
- Sometimes data array  with hash type require deduplication too.