### PR TITLE
Add on directive to switch as an alternative to case

### DIFF
--- a/freemarker-core/src/main/java/freemarker/core/On.java
+++ b/freemarker-core/src/main/java/freemarker/core/On.java
@@ -1,0 +1,95 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package freemarker.core;
+
+import java.util.List;
+
+/**
+ * Represents an "on" in a switch statement.
+ * This is alternative to case that does not fall-though
+ * and instead supports multiple conditions.
+ */
+final class On extends TemplateElement {
+
+    List<Expression> conditions;
+
+    On(List<Expression> matchingValues, TemplateElements children) {
+        this.conditions = matchingValues;
+        setChildren(children);
+    }
+
+    @Override
+    TemplateElement[] accept(Environment env) {
+        return getChildBuffer();
+    }
+
+    @Override
+    protected String dump(boolean canonical) {
+        StringBuilder sb = new StringBuilder();
+        if (canonical) sb.append('<');
+        sb.append(getNodeTypeSymbol());
+        for (int i = 0; i < conditions.size(); i++) {
+            if (i != 0) {
+                sb.append(',');
+            }
+            sb.append(' ');
+            sb.append((conditions.get(i)).getCanonicalForm());
+        }
+        if (canonical) {
+            sb.append('>');
+            sb.append(getChildrenCanonicalForm());
+        }
+        return sb.toString();
+    }
+
+    @Override
+    String getNodeTypeSymbol() {
+        return "#on";
+    }
+
+    @Override
+    int getParameterCount() {
+        return conditions.size();
+    }
+
+    @Override
+    Object getParameterValue(int idx) {
+        checkIndex(idx);
+        return conditions.get(idx);
+    }
+
+    @Override
+    ParameterRole getParameterRole(int idx) {
+        checkIndex(idx);
+        return ParameterRole.CONDITION;
+    }
+
+    private void checkIndex(int idx) {
+        if (conditions == null || idx >= conditions.size()) {
+            throw new IndexOutOfBoundsException();
+        }
+    }
+
+    @Override
+    boolean isNestedBlockRepeater() {
+        return false;
+    }
+
+}

--- a/freemarker-core/src/main/java/freemarker/core/_CoreAPI.java
+++ b/freemarker-core/src/main/java/freemarker/core/_CoreAPI.java
@@ -105,6 +105,7 @@ public class _CoreAPI {
         addName(allNames, lcNames, ccNames, "noescape", "noEscape");
         addName(allNames, lcNames, ccNames, "noparse", "noParse");
         addName(allNames, lcNames, ccNames, "nt");
+        addName(allNames, lcNames, ccNames, "on");
         addName(allNames, lcNames, ccNames, "outputformat", "outputFormat");
         addName(allNames, lcNames, ccNames, "recover");
         addName(allNames, lcNames, ccNames, "recurse");

--- a/freemarker-core/src/main/javacc/freemarker/core/FTL.jj
+++ b/freemarker-core/src/main/javacc/freemarker/core/FTL.jj
@@ -3884,9 +3884,9 @@ SwitchBlock Switch() :
 }
 {
     (
-	    start = <SWITCH>
-	    switchExp = Expression()
-	    <DIRECTIVE_END>
+        start = <SWITCH>
+        switchExp = Expression()
+        <DIRECTIVE_END>
         [ ignoredSectionBeforeFirstCase = WhitespaceAndComments() ]
     )
     {
@@ -3894,7 +3894,7 @@ SwitchBlock Switch() :
         switchBlock = new SwitchBlock(switchExp, ignoredSectionBeforeFirstCase);
     }
     [
-	    (
+        (
             (
                 caseIns = Case()
                 {
@@ -3938,8 +3938,8 @@ SwitchBlock Switch() :
                     breakableDirectiveNesting++;
                 }
             )
-	    )
-	    [<STATIC_TEXT_WS>]
+        )
+        [<STATIC_TEXT_WS>]
     ]
     end = <END_SWITCH>
     {

--- a/freemarker-core/src/main/javacc/freemarker/core/FTL.jj
+++ b/freemarker-core/src/main/javacc/freemarker/core/FTL.jj
@@ -953,6 +953,8 @@ TOKEN:
     |
     <CASE : <START_TAG> "case" <BLANK>> { handleTagSyntaxAndSwitch(matchedToken, FM_EXPRESSION); }
     |
+    <ON : <START_TAG> "on" <BLANK>> { handleTagSyntaxAndSwitch(matchedToken, FM_EXPRESSION); }
+    |
     <ASSIGN : <START_TAG> "assign" <BLANK>> { handleTagSyntaxAndSwitch(matchedToken, FM_EXPRESSION); }
     |
     <GLOBALASSIGN : <START_TAG> "global" <BLANK>> { handleTagSyntaxAndSwitch(matchedToken, FM_EXPRESSION); }
@@ -3875,6 +3877,7 @@ SwitchBlock Switch() :
     SwitchBlock switchBlock;
     MixedContent ignoredSectionBeforeFirstCase = null;
     Case caseIns;
+    On onIns;
     Expression switchExp;
     Token start, end;
     boolean defaultFound = false;
@@ -3892,18 +3895,50 @@ SwitchBlock Switch() :
     }
     [
 	    (
-	        caseIns = Case()
-	        {
-	            if (caseIns.condition == null) {
-	                if (defaultFound) {
-	                    throw new ParseException(
-	                    "You can only have one default case in a switch statement", template, start);
-	                }
-	                defaultFound = true;
-	            }
-	            switchBlock.addCase(caseIns);
-	        }
-	    )+
+            (
+                caseIns = Case()
+                {
+                    if (caseIns.condition == null) {
+                        if (defaultFound) {
+                            throw new ParseException(
+                            "You can only have one default case in a switch statement", template, start);
+                        }
+                        defaultFound = true;
+                    }
+                    switchBlock.addCase(caseIns);
+                }
+            )+
+            |
+            (
+                {
+                    // A Switch with Case supports break, but not one with On.
+                    // Do it this way to ensure backwards compatibility.
+                    breakableDirectiveNesting--;
+                }
+
+                (
+                    onIns = On()
+                    {
+                        switchBlock.addOn(onIns);
+                    }
+                )+
+                [
+                    caseIns = Case()
+                    {
+                        // When using on, you can have a default, but not a normal case
+                        if (caseIns.condition != null) {
+                            throw new ParseException(
+                            "You cannot mix \"case\" and \"on\" in a switch statement", template, start);
+                        }
+                        switchBlock.addCase(caseIns);
+                    }
+                ]
+
+                {
+                    breakableDirectiveNesting++;
+                }
+            )
+	    )
 	    [<STATIC_TEXT_WS>]
     ]
     end = <END_SWITCH>
@@ -3929,6 +3964,24 @@ Case Case() :
     children = MixedContentElements()
     {
         Case result = new Case(exp, children);
+        result.setLocation(template, start, start, children);
+        return result;
+    }
+}
+
+On On() :
+{
+    ArrayList exps;
+    TemplateElements children;
+    Token start;
+}
+{
+    (
+        start = <ON> exps = PositionalArgs() <DIRECTIVE_END>
+    )
+    children = MixedContentElements()
+    {
+        On result = new On(exps, children);
         result.setLocation(template, start, start, children);
         return result;
     }

--- a/freemarker-core/src/test/java/freemarker/core/BreakAndContinuePlacementTest.java
+++ b/freemarker-core/src/test/java/freemarker/core/BreakAndContinuePlacementTest.java
@@ -46,9 +46,12 @@ public class BreakAndContinuePlacementTest extends TemplateTest {
                 + "<#list xs>[<#items as x>${x}</#items>]<#else><#break></#list>"
                 + "</#list>.",
                 "[12][34].");
+        assertOutput("<#list 1..2 as x><#switch x><#on 1>one<#break></#switch>;</#list>", "one");
+        assertOutput("<#list 1..2 as x><#switch x><#on 1>one<#continue></#switch>;</#list>", "one;");
         assertOutput("<#forEach x in 1..2>${x}<#break></#forEach>", "1");
         assertOutput("<#forEach x in 1..2>${x}<#continue></#forEach>", "12");
         assertOutput("<#switch 1><#case 1>1<#break></#switch>", "1");
+        assertOutput("<#switch 1><#default>1<#break></#switch>", "1");
     }
 
     @Test
@@ -56,6 +59,9 @@ public class BreakAndContinuePlacementTest extends TemplateTest {
         assertErrorContains("<#break>", BREAK_NESTING_ERROR_MESSAGE_PART);
         assertErrorContains("<#continue>", CONTINUE_NESTING_ERROR_MESSAGE_PART);
         assertErrorContains("<#switch 1><#case 1>1<#continue></#switch>", CONTINUE_NESTING_ERROR_MESSAGE_PART);
+        assertErrorContains("<#switch 1><#on 1>1<#continue></#switch>", CONTINUE_NESTING_ERROR_MESSAGE_PART);
+        assertErrorContains("<#switch 1><#on 1>1<#break></#switch>", BREAK_NESTING_ERROR_MESSAGE_PART);
+        assertErrorContains("<#switch 1><#on 1>1<#default><#break></#switch>", BREAK_NESTING_ERROR_MESSAGE_PART);
         assertErrorContains("<#list 1..2 as x>${x}</#list><#break>", BREAK_NESTING_ERROR_MESSAGE_PART);
         assertErrorContains("<#if false><#break></#if>", BREAK_NESTING_ERROR_MESSAGE_PART);
         assertErrorContains("<#list xs><#break></#list>", BREAK_NESTING_ERROR_MESSAGE_PART);

--- a/freemarker-core/src/test/java/freemarker/core/TemplateProcessingTracerTest.java
+++ b/freemarker-core/src/test/java/freemarker/core/TemplateProcessingTracerTest.java
@@ -65,6 +65,15 @@ public class TemplateProcessingTracerTest {
             "<#case 2>C3<#break>" +
             "<#default>D" +
             "</#switch>" +
+            "<#switch 4>" +
+            "<#on 1>O1" +
+            "<#on 4>O4" +
+            "<#default>D" +
+            "</#switch>" +
+            "<#switch 5>" +
+            "<#on 1>O1" +
+            "<#default>OD" +
+            "</#switch>" +
             "<#macro m>Hello from m!</#macro>" +
             "Calling macro: <@m />" +
             "<#assign t>captured</#assign>" +
@@ -121,6 +130,8 @@ public class TemplateProcessingTracerTest {
                         "C2",
                         "<#break>",
                         "D",
+                        "O4",
+                        "OD",
                         "Calling macro: ",
                         "<@m />",
                         "Hello from m!",
@@ -191,6 +202,12 @@ public class TemplateProcessingTracerTest {
                         " #switch 3",
                         "  #default",
                         "   text \"D\"",
+                        " #switch 4",
+                        "  #on 4",
+                        "   text \"O4\"",
+                        " #switch 5",
+                        "  #default",
+                        "   text \"OD\"",
                         " #macro m",
                         " text \"Calling macro: \"",
                         " @m",

--- a/freemarker-core/src/test/resources/freemarker/core/ast-1.ast
+++ b/freemarker-core/src/test/resources/freemarker/core/ast-1.ast
@@ -112,6 +112,24 @@
                 - content: "more"  // String
     #text  // f.c.TextBlock
         - content: "\n6 "  // String
+    #switch  // f.c.SwitchBlock
+        - value: x  // f.c.Identifier
+        #on  // f.c.On
+            - condition: 1  // f.c.NumberLiteral
+            - condition: 2  // f.c.NumberLiteral
+            #text  // f.c.TextBlock
+                - content: "one or two"  // String
+        #on  // f.c.On
+            - condition: 3  // f.c.NumberLiteral
+            #text  // f.c.TextBlock
+                - content: "three"  // String
+        #default  // f.c.Case
+            - condition: null  // Null
+            - AST-node subtype: "1"  // Integer
+            #text  // f.c.TextBlock
+                - content: "more"  // String
+    #text  // f.c.TextBlock
+        - content: "\n7 "  // String
     #macro  // f.c.Macro
         - assignment target: "foo"  // String
         - parameter name: "x"  // String
@@ -128,7 +146,7 @@
             - passed value: x  // f.c.Identifier
             - passed value: y  // f.c.Identifier
     #text  // f.c.TextBlock
-        - content: "\n7 "  // String
+        - content: "\n8 "  // String
     #function  // f.c.Macro
         - assignment target: "foo"  // String
         - parameter name: "x"  // String
@@ -146,12 +164,12 @@
         #return  // f.c.ReturnInstruction
             - value: 1  // f.c.NumberLiteral
     #text  // f.c.TextBlock
-        - content: "\n8 "  // String
+        - content: "\n9 "  // String
     #list  // f.c.IteratorBlock
         - list source: xs  // f.c.Identifier
         - target loop variable: "x"  // String
     #text  // f.c.TextBlock
-        - content: "\n9 "  // String
+        - content: "\n10 "  // String
     #list-#else-container  // f.c.ListElseContainer
         #list  // f.c.IteratorBlock
             - list source: xs  // f.c.Identifier
@@ -170,11 +188,11 @@
             #text  // f.c.TextBlock
                 - content: "None"  // String
     #text  // f.c.TextBlock
-        - content: "\n10 "  // String
+        - content: "\n11 "  // String
     #--...--  // f.c.Comment
         - content: " A comment "  // String
     #text  // f.c.TextBlock
-        - content: "\n11 "  // String
+        - content: "\n12 "  // String
     #outputformat  // f.c.OutputFormatBlock
         - value: "XML"  // f.c.StringLiteral
         #noautoesc  // f.c.NoAutoEscBlock

--- a/freemarker-core/src/test/resources/freemarker/core/ast-1.ftl
+++ b/freemarker-core/src/test/resources/freemarker/core/ast-1.ftl
@@ -21,9 +21,10 @@
 3 <#assign x = 123><#assign x = 123 in ns><#global x = 123>
 4 <#if x + 1 == 0>foo${y}bar<#else>${"static"}${'x${baaz * 10}y'}</#if>
 5 <#switch x><#case 1>one<#case 2>two<#default>more</#switch>
-6 <#macro foo x y=2 z=y+1 q...><#nested x y></#macro>
-7 <#function foo x y><#local x = 123><#return 1></#function>
-8 <#list xs as x></#list>
-9 <#list xs>[<#items as x>${x}<#sep>, </#items>]<#else>None</#list>
-10 <#-- A comment -->
-11 <#outputFormat "XML"><#noAutoEsc>${a}<#autoEsc>${b}</#autoEsc>${c}</#noAutoEsc></#outputFormat>
+6 <#switch x><#on 1, 2>one or two<#on 3>three<#default>more</#switch>
+7 <#macro foo x y=2 z=y+1 q...><#nested x y></#macro>
+8 <#function foo x y><#local x = 123><#return 1></#function>
+9 <#list xs as x></#list>
+10 <#list xs>[<#items as x>${x}<#sep>, </#items>]<#else>None</#list>
+11 <#-- A comment -->
+12 <#outputFormat "XML"><#noAutoEsc>${a}<#autoEsc>${b}</#autoEsc>${c}</#noAutoEsc></#outputFormat>


### PR DESCRIPTION
This is a copy of #106 which was backed out after a problem with the contributors agreement.

---

The current `switch` directive is not recommended due to its fall-through behavior being regarded as error-prone. To solve this problem, we introduce a new `on` directive as an alternative to `case`, which doesn't support fall-through. This new directive allows specifying multiple comma-separated conditions in order to address the primary motivator for using fall-through with `case`.

## Example

Using `case`:
```freemarker
<#switch animal.size>
  <#case "tiny">
  <#case "small">
     This will be processed if it is small
     <#break>
  <#case "medium">
     This will be processed if it is medium
     <#break>
  <#default>
     This will be processed if it is neither
</#switch>
```
Using `on`:
```freemarker
<#switch animal.size>
  <#on "tiny", "small">
     This will be processed if it is small
  <#on "medium">
     This will be processed if it is medium
  <#default>
     This will be processed if it is neither
</#switch>
```

## Details

* Mixing `case` and `on` directives is disallowed and will fail.
* If a `switch` contains an `on`, then using `break` or `continue` is not supported (applying to both `on` and `default`). In this situation, `break` and `continue` will follow the behavior of the containing scope, e.g. of a containing `list`. This does mean that if someone accidentally uses `break` with `on`, they could potentially become confused.

### Additional Notes

* When `on` is not used, the legacy behavior for `case`/`default` is that `continue` will be treated as `break`. If we wish to change this, then that work can be done separately.
* If using `default`, the parser also allows it to appear before or between `case` directives, but when using `on` then `default` is only allowed after.