### PR TITLE
docs: wrong `with_args` output

### DIFF
--- a/freemarker-manual/src/main/docgen/en_US/book.xml
+++ b/freemarker-manual/src/main/docgen/en_US/book.xml
@@ -20741,7 +20741,7 @@ Again:
 
           <programlisting role="template">&lt;@m?with_args(dynArgs) /&gt;</programlisting>
 
-          <programlisting role="output">a=1, b=1, c=1</programlisting>
+          <programlisting role="output">a=1, b=2, c=3</programlisting>
 
           <para>Below call also does the same, but combines dynamic arguments
           from <literal>dynArgsAB</literal>, assumed to be <literal>{'a': 1,
@@ -20750,7 +20750,7 @@ Again:
 
           <programlisting role="template">&lt;@m?with_args(dynArgsAB) c=3 /&gt;</programlisting>
 
-          <programlisting role="output">a=1, b=1, c=1</programlisting>
+          <programlisting role="output">a=1, b=2, c=3</programlisting>
 
           <para>To understand why this works, you need to realize that macros,
           custom directives, functions, and methods in FreeMarker are just


### PR DESCRIPTION
The output of these two examples shoule be `a=1, b=2, c=3` instead of `a=1, b=1, c=1`
<img width="1005" alt="image" src="https://github.com/user-attachments/assets/516cac1c-d54a-46d0-ae90-2d311ff2aa1c">


Docs link: https://freemarker.apache.org/docs/ref_builtins_expert.html#ref_builtin_with_args