### PR TITLE
Fix sep directive in syntax A breaks templates in syntax B

### DIFF
--- a/freemarker-core/src/main/javacc/freemarker/core/FTL.jj
+++ b/freemarker-core/src/main/javacc/freemarker/core/FTL.jj
@@ -685,7 +685,7 @@ TOKEN_MGR_DECLS:
         }
         
         // For square bracket tags there's no non-strict token, so we are sure that it's an FTL tag.
-        // But if it's an angle bracket tag, we have to check if it's just static text or and FTL tag, because the
+        // But if it's an angle bracket tag, we have to check if it's just static text or an FTL tag, because the
         // tokenizer will emit the same kind of token for both.
         if (!squBracTagSyntax && !isStrictTag(image)) {
             tok.kind = STATIC_TEXT_NON_WS;

--- a/freemarker-core/src/main/javacc/freemarker/core/FTL.jj
+++ b/freemarker-core/src/main/javacc/freemarker/core/FTL.jj
@@ -943,7 +943,7 @@ TOKEN:
     |
     <ITEMS : <START_TAG> "items" (<BLANK>)+ <AS> <BLANK>> { handleTagSyntaxAndSwitch(matchedToken, FM_EXPRESSION); }
     |
-    <SEP : <START_TAG> "sep" <CLOSE_TAG1>>
+    <SEP : <START_TAG> "sep" <CLOSE_TAG1>> { handleTagSyntaxAndSwitch(matchedToken, DEFAULT); }
     |
     <FOREACH : <START_TAG> "for" ("e" | "E") "ach" <BLANK>> {
         handleTagSyntaxAndSwitch(matchedToken, getTagNamingConvention(matchedToken, 3), FM_EXPRESSION);

--- a/freemarker-core/src/test/java/freemarker/core/ListSepTest.java
+++ b/freemarker-core/src/test/java/freemarker/core/ListSepTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package freemarker.core;
+
+import freemarker.template.*;
+import freemarker.test.TemplateTest;
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class ListSepTest extends TemplateTest {
+
+    @Test
+    public void testAngleBracketSepDoesNotBreakSquareBracketTemplate() throws IOException, TemplateException {
+        assertOutput(
+                "<#list values as value>${value}<#sep>, </#list>'",
+                "<#list values as value>${value}<#sep>, </#list>'"
+        );
+    }
+
+    @Override
+    protected Configuration createConfiguration() throws Exception {
+        Configuration conf = super.createConfiguration();
+        conf.setTagSyntax(Configuration.SQUARE_BRACKET_TAG_SYNTAX);
+        conf.setInterpolationSyntax(Configuration.SQUARE_BRACKET_INTERPOLATION_SYNTAX);
+        return conf;
+    }
+}


### PR DESCRIPTION
I noticed compiling a template containing `<#sep>` using a configuration specifying the square bracket tag syntax fails with a `freemarker.core.ParseException: Syntax error in template "X" in line Y, column Z: #sep must be inside a #list (or #foreach) block.` I think `<#sep>` should be ignored instead as it is not using the square bracket syntax.

This PR adds a unit test covering that case, a change in `FTL.jj` that solves the issue, and fixes a typo.

`./gradlew check` runs successfully for me with these changes, but I do not know the Freemarker codebase well enough to be confident that it does not introduce other issues.

I'd be happy to improve this PR if there is any feedback.