### PR TITLE
Added GraalVM native support to Apache FreeMarker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,9 @@ jobs:
   build:
     strategy:
         matrix:
-            os: [windows-latest, ubuntu-latest]
+            os: [windows-latest, ubuntu-latest, ubuntu-24.04-arm]
     runs-on: ${{ matrix.os }}
-    concurrency: main_tests_${{ github.ref }}
+    concurrency: main_tests_${{ github.ref }}_${{ matrix.os }}
     steps:
       - name: Welcome Message
         run: 'echo "Started with parameters: ${{ matrix.os }} because ${{ github.event_name }} on ${{ github.ref }}"'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,33 @@ jobs:
       - name: Run Build
         id: build_step
         run: './gradlew "-Pfreemarker.signMethod=none" "-Pfreemarker.allowUnsignedReleaseBuild=true" --continue clean build'
+      - name: Set up GraalVM 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: 21
+          distribution: graalvm
+        # test pipeline to check native support
+        #
+        # - GraalVM is added to the runner
+        # - A simple native project is build and run
+        #
+        # At the something like that should be found in the log :
+        #
+        # INFO: name : FreeMarker Native Demo, version : 2.3.35-nightly
+        # Jan 15, 2025 4:28:19 PM freemarker.log._JULLoggerFactory$JULLogger info
+        # INFO: result :
+        # <html>
+        #    <head>
+        #        <title>Hello : FreeMarker GraalVM Native Demo</title>
+        #    </head>
+        #    <body>
+        #        <h1>Hello : FreeMarker GraalVM Native Demo</h1>
+        #        <p>Test template for Apache FreeMarker GraalVM native support (2.3.35-nightly)</p>
+        #    </body>
+        # </html>
+      - name: Test GraalVM native support (build and run)
+        id: native_test
+        run: './gradlew :freemarker-test-graalvm-native:nativeCompile;./freemarker-test-graalvm-native/build/native/nativeCompile/freemarker-test-graalvm-native'
       - name: Upload Failed Report
         uses: actions/upload-artifact@v4
         if: failure() && steps.build_step.outcome == 'failure'

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ Apache FreeMarker™ {version}
 ============================
 
 [![Build status](https://github.com/apache/freemarker/actions/workflows/ci.yml/badge.svg)](https://github.com/apache/freemarker/actions/workflows/ci.yml)
+![GraalVM Ready](https://img.shields.io/badge/GraalVM-Ready-orange)
 
 For the latest version or to report bugs visit:
 https://freemarker.apache.org/

--- a/README.md
+++ b/README.md
@@ -253,3 +253,14 @@ Gradle project. After that, it's recommended to set these preferences (based on 
   - Project -> Properties -> FindBugs -> [x] Run Automatically
   - There should 0 errors. But sometimes the plugin fails to take the
     @SuppressFBWarnings annotations into account; then use Project -> Clean. 
+
+### GraalVM Native Support
+
+Apache FreeMarker is compatible with Ahead-of-Time (AOT) compilation using GraalVM as of version 2.3.35. However, any custom Java objects or resources used in the data model must still be registered for reflection.
+
+Refer to the [GraalVM documentation](https://www.graalvm.org/latest/docs/) for more details, especially:
+
+- [Reflection in Native Image](https://www.graalvm.org/jdk21/reference-manual/native-image/dynamic-features/Reflection/)
+- [Accessing Resources in Native Image](https://www.graalvm.org/jdk21/reference-manual/native-image/dynamic-features/Resources/)
+
+**TIP:** You can find many configuration samples in the [graalvm-reachability-metadata](https://github.com/oracle/graalvm-reachability-metadata) repository.

--- a/README.md
+++ b/README.md
@@ -264,3 +264,130 @@ Refer to the [GraalVM documentation](https://www.graalvm.org/latest/docs/) for m
 - [Accessing Resources in Native Image](https://www.graalvm.org/jdk21/reference-manual/native-image/dynamic-features/Resources/)
 
 **TIP:** You can find many configuration samples in the [graalvm-reachability-metadata](https://github.com/oracle/graalvm-reachability-metadata) repository.
+
+Here is a sample usage guide for ApacheFreeMarker + GraalVM.
+
+To run the sample in classic Just In Time Way, we only need :
+
+* FreeMarkerGraalVMSample.java
+* sample.ftl
+
+But for the Ahead Of Time application with GraalVM some additional configuration is required :
+
+* custom-reflect-config.json
+
+#### FreeMarkerGraalVMSample.java sample class
+
+```java
+import freemarker.log.Logger;
+import freemarker.template.Configuration;
+import freemarker.template.Template;
+import freemarker.template.TemplateException;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.util.HashMap;
+import java.util.Map;
+
+public class FreeMarkerGraalVMSample {
+
+    private final static Logger LOG = Logger.getLogger(FreeMarkerGraalVMSample.class.getName());
+
+    /* data model */
+    public class Data {
+        private String description;
+        public String getDescription() {
+            return description;
+        }
+        public void setDescription(String description) {
+            this.description = description;
+        }
+    }
+
+    private void handleTemplate(Writer writer, String templatePath, Map<String, Object> dataModel) throws IOException, TemplateException {
+        Configuration cfg = new Configuration( Configuration.VERSION_2_3_34 );
+        cfg.setClassForTemplateLoading( FreeMarkerGraalVMSample.class, "/templates" );
+        Template template = cfg.getTemplate( templatePath );
+        template.process( dataModel, writer );
+    }
+
+    public void runSample() {
+        try ( StringWriter writer = new StringWriter() ) {
+            Map<String, Object> dataModel = new HashMap<>();
+            Data data = new Data();
+            data.setDescription( "FreeMarkerGraalVMSample" );
+            dataModel.put("data", data);
+            handleTemplate( writer, "sample.ftl", dataModel );
+            LOG.info( writer.toString() );
+        } catch (Exception e) {
+            LOG.error( e.getMessage(), e );
+        }
+    }
+
+    public static void main(String[] args) {
+        FreeMarkerGraalVMSample sample = new FreeMarkerGraalVMSample();
+        sample.runSample();
+    }
+
+}
+```
+
+#### Apache FreeMarker template
+
+```ftl
+<freemarker-graalvm-sample>
+    <freemarker-version>${.version}</freemarker-version>
+    <description>${data.description}</description>
+</freemarker-graalvm-sample>
+```
+
+#### Reflection configuration, custom-reflect-config.json
+
+Refers to [Reflection in Native Image](https://www.graalvm.org/jdk21/reference-manual/native-image/dynamic-features/Reflection/) guide
+
+```json
+[{
+  "name" : "FreeMarkerGraalVMSample$Data",
+  "methods" : [ {
+    "name" : "<init>",
+    "parameterTypes" : [ ]
+  },{
+    "name" : "getDescription",
+    "parameterTypes" : [ ]
+  } ]
+}]
+```
+
+#### Build the native image
+
+```shell
+#!/bin/bash
+
+# setting up environment
+export BASEDIR=.
+export CP=./lib/freemarker-gae-2.3.35-SNAPSHOT.jar:.
+
+# just in time application build
+javac -cp ${CP} -d build ./src/FreeMarkerGraalVMSample.java
+
+# ahead of time application build
+#
+# -H:IncludeResources=^templates/.* 
+#      will make the templates available to the native-image
+#
+# -H:ReflectionConfigurationFiles=./config/custom-reflect-config.json
+#      will setup reflection custom configuration
+native-image \
+  -cp "${CP}:build" \
+  -H:Path=build \
+  -H:Class=FreeMarkerGraalVMSample \
+  -H:IncludeResources=^templates/.* \
+  -H:+UnlockExperimentalVMOptions \
+  -H:ReflectionConfigurationFiles=./config/custom-reflect-config.json \
+  --no-fallback \
+  --report-unsupported-elements-at-runtime
+
+# running the application
+./build/freemarkergraalvmsample
+```

--- a/freemarker-core/src/main/resources/META-INF/native-image/org.freemarker/freemarker/native-image.properties
+++ b/freemarker-core/src/main/resources/META-INF/native-image/org.freemarker/freemarker/native-image.properties
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+Args = --initialize-at-run-time=freemarker.ext.jython.JythonWrapper,\
+       --initialize-at-run-time=freemarker.ext.jython.JythonModel

--- a/freemarker-core/src/main/resources/META-INF/native-image/org.freemarker/freemarker/reflect-config.json
+++ b/freemarker-core/src/main/resources/META-INF/native-image/org.freemarker/freemarker/reflect-config.json
@@ -1,0 +1,82 @@
+[ {
+  "condition" : {
+    "typeReachable" : "freemarker.template.Configuration"
+  },
+  "name" : "freemarker.log._SLF4JLoggerFactory",
+  "methods" : [ {
+    "name" : "<init>",
+    "parameterTypes" : [ ]
+  } ]
+}, {
+  "condition" : {
+    "typeReachable" : "freemarker.template.Configuration"
+  },
+  "name" : "freemarker.log.SLF4JLoggerFactory",
+  "methods" : [ {
+    "name" : "<init>",
+    "parameterTypes" : [ ]
+  } ]
+}, {
+  "condition" : {
+    "typeReachable" : "freemarker.template.Configuration"
+  },
+  "name" : "freemarker.log._AvalonLoggerFactory.java",
+  "methods" : [ {
+    "name" : "<init>",
+    "parameterTypes" : [ ]
+  } ]
+}, {
+  "condition" : {
+    "typeReachable" : "freemarker.template.Configuration"
+  },
+  "name" : "freemarker.log._CommonsLoggingLoggerFactory.java",
+  "methods" : [ {
+    "name" : "<init>",
+    "parameterTypes" : [ ]
+  } ]
+}, {
+  "condition" : {
+    "typeReachable" : "freemarker.template.Configuration"
+  },
+  "name" : "freemarker.log._JULLoggerFactory.java",
+  "methods" : [ {
+    "name" : "<init>",
+    "parameterTypes" : [ ]
+  } ]
+}, {
+  "condition" : {
+    "typeReachable" : "freemarker.template.Configuration"
+  },
+  "name" : "freemarker.log._Log4jLoggerFactory.java",
+  "methods" : [ {
+    "name" : "<init>",
+    "parameterTypes" : [ ]
+  } ]
+}, {
+  "condition" : {
+    "typeReachable" : "freemarker.template.Configuration"
+  },
+  "name" : "freemarker.log._Log4jOverSLF4JTester.java",
+  "methods" : [ {
+    "name" : "<init>",
+    "parameterTypes" : [ ]
+  } ]
+}, {
+  "condition" : {
+    "typeReachable" : "freemarker.template.Configuration"
+  },
+  "name" : "freemarker.log._NullLoggerFactory.java",
+  "methods" : [ {
+    "name" : "<init>",
+    "parameterTypes" : [ ]
+  } ]
+}, {
+  "condition" : {
+    "typeReachable" : "freemarker.template.Configuration"
+  },
+  "name" : "freemarker.log.CommonsLoggingLoggerFactory.java",
+  "methods" : [ {
+    "name" : "<init>",
+    "parameterTypes" : [ ]
+  } ]
+}  ]

--- a/freemarker-core/src/main/resources/META-INF/native-image/org.freemarker/freemarker/resource-config.json
+++ b/freemarker-core/src/main/resources/META-INF/native-image/org.freemarker/freemarker/resource-config.json
@@ -1,0 +1,25 @@
+{
+  "bundles": [],
+  "resources": {
+    "includes": [
+      {
+        "pattern": "\\Qfreemarker/ext/beans/DefaultMemberAccessPolicy-rules\\E",
+        "condition": {
+          "typeReachable": "freemarker.ext.beans.DefaultMemberAccessPolicy"
+        }
+      },
+      {
+        "pattern": "\\Qfreemarker/ext/beans/unsafeMethods.properties\\E",
+        "condition": {
+          "typeReachable": "freemarker.ext.beans.LegacyDefaultMemberAccessPolicy"
+        }
+      },
+      {
+        "pattern": "\\Qfreemarker/version.properties\\E",
+        "condition": {
+          "typeReachable": "freemarker.template.utility.ClassUtil"
+        }
+      }
+    ]
+  }
+}

--- a/freemarker-test-graalvm-native/README.md
+++ b/freemarker-test-graalvm-native/README.md
@@ -1,0 +1,48 @@
+# freemarker-test-graalvm-natice
+
+Test project for GraalVM support
+
+Requirements : 
+
+- GraalVM 21+
+
+## Quickstart
+
+1. Build the main Apache FreeMarker proejct : 
+
+```shell
+./gradlew "-Pfreemarker.signMethod=none" "-Pfreemarker.allowUnsignedReleaseBuild=true" clean build
+```
+
+2. Build the test module native image with GraalVM : 
+
+```shell
+./gradlew :freemarker-test-graalvm-native:nativeCompile 
+```
+
+3. Run the project :
+
+```shell
+./freemarker-test-graalvm-native/build/native/nativeCompile/freemarker-test-graalvm-native 
+```
+
+Output should be similar to : 
+
+```txt
+INFO: name : FreeMarker Native Demo, version : 2.3.35-nightly
+Jan 15, 2025 4:28:19 PM freemarker.log._JULLoggerFactory$JULLogger info
+INFO: result :
+<html>
+    <head>
+        <title>Hello : FreeMarker GraalVM Native Demo</title>
+    </head>
+    <body>
+        <h1>Hello : FreeMarker GraalVM Native Demo</h1>
+        <p>Test template for Apache FreeMarker GraalVM native support (2.3.35-nightly)</p>
+    </body>
+</html>
+```
+
+## CI (GitHub workflow)
+
+GraalVM native test for this module is included in the GitHub  [CI](../.github/workflows/ci.yml) worflow.

--- a/freemarker-test-graalvm-native/build.gradle.kts
+++ b/freemarker-test-graalvm-native/build.gradle.kts
@@ -1,0 +1,71 @@
+import org.graalvm.buildtools.gradle.tasks.BuildNativeImageTask
+import java.util.Arrays
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+plugins {
+    java
+    application
+    id("org.graalvm.buildtools.native") version "0.10.3"
+}
+
+group = "org.freemarker"
+version = rootProject.version
+
+val graalSdkVersion = "24.1.1"
+val junitJupiterVersion = "5.11.4"
+
+val profile = findProperty("profile") as String? ?: "default"
+
+dependencies {
+    implementation(project(":"))
+    implementation("org.python:jython:2.5.0")
+    compileOnly("org.graalvm.sdk:graal-sdk:$graalSdkVersion")
+    testImplementation("org.junit.jupiter:junit-jupiter-api:$junitJupiterVersion")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:$junitJupiterVersion")
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+    withSourcesJar()
+    withJavadocJar()
+}
+
+application {
+    mainClass.set("org.freemarker.core.graal.HelloFreeMarker")
+}
+
+tasks.test {
+    useJUnitPlatform()
+    testLogging {
+        events("PASSED", "FAILED", "SKIPPED")
+    }
+}
+
+graalvmNative {
+    binaries.all {
+        fallback.set(false)
+        verbose.set(true)
+        resources.autodetect()
+        buildArgs.add( "-H:ReflectionConfigurationFiles=$projectDir/src/main/config/reflect-config.json" )
+        jvmArgs()
+    }
+}

--- a/freemarker-test-graalvm-native/src/main/config/reflect-config.json
+++ b/freemarker-test-graalvm-native/src/main/config/reflect-config.json
@@ -1,0 +1,9 @@
+[
+  {
+    "name": "org.freemarker.core.graal.HelloDataModel",
+    "methods": [
+      { "name": "getName", "parameterTypes": [] },
+      { "name": "getVersion", "parameterTypes": [] }
+    ]
+  }
+]

--- a/freemarker-test-graalvm-native/src/main/java/org/freemarker/core/graal/HelloDataModel.java
+++ b/freemarker-test-graalvm-native/src/main/java/org/freemarker/core/graal/HelloDataModel.java
@@ -17,22 +17,28 @@
  * under the License.
  */
 
-rootProject.name = "freemarker-gae"
+package org.freemarker.core.graal;
 
-apply(from = rootDir.toPath().resolve("gradle").resolve("repositories.gradle.kts"))
+public class HelloDataModel {
 
-plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention") version "0.7.0"
-}
+    private String name;
 
-dependencyResolutionManagement {
-    versionCatalogs {
-        create("libs") {
-            version("junit", "4.12")
+    private String version;
 
-            library("junit", "junit", "junit").versionRef("junit")
-        }
+    public String getVersion() {
+        return version;
     }
-}
 
-include("freemarker-test-graalvm-native")
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+}

--- a/freemarker-test-graalvm-native/src/main/java/org/freemarker/core/graal/HelloFreeMarker.java
+++ b/freemarker-test-graalvm-native/src/main/java/org/freemarker/core/graal/HelloFreeMarker.java
@@ -17,22 +17,17 @@
  * under the License.
  */
 
-rootProject.name = "freemarker-gae"
+package org.freemarker.core.graal;
 
-apply(from = rootDir.toPath().resolve("gradle").resolve("repositories.gradle.kts"))
+import freemarker.log.Logger;
 
-plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention") version "0.7.0"
-}
+public class HelloFreeMarker {
 
-dependencyResolutionManagement {
-    versionCatalogs {
-        create("libs") {
-            version("junit", "4.12")
+    private final static Logger log = Logger.getLogger(HelloFreeMarker.class.getName());
 
-            library("junit", "junit", "junit").versionRef("junit")
-        }
+    public static void main( String[] args ) throws Exception {
+        HelloHandler helloHandler = new HelloHandler();
+        helloHandler.sayHello();
     }
-}
 
-include("freemarker-test-graalvm-native")
+}

--- a/freemarker-test-graalvm-native/src/main/java/org/freemarker/core/graal/HelloHandler.java
+++ b/freemarker-test-graalvm-native/src/main/java/org/freemarker/core/graal/HelloHandler.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.freemarker.core.graal;
+
+import freemarker.log.Logger;
+import freemarker.template.Configuration;
+import freemarker.template.Template;
+import freemarker.template.Version;
+
+import java.io.StringWriter;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Simple test class, able to say hello.
+ */
+public class HelloHandler {
+
+    private final static Logger log = Logger.getLogger(HelloHandler.class.getName());
+
+    public HelloHandler() throws ClassNotFoundException {
+        // test native configuration
+        Class.forName("freemarker.ext.jython.JythonModel");
+    }
+
+    /**
+     * This method will say hello by printing an Apache FreeMarker template
+     *
+     * @throws Exception    if any unexpected situation occurs
+     */
+    public void sayHello() throws Exception {
+        try (StringWriter buffer = new StringWriter()) {
+            Version version = new Version(Configuration.getVersion().toString());  // using latest version
+            // creates FreeMarker configuration
+            Configuration cfg = new Configuration( version );
+            cfg.setClassForTemplateLoading(HelloDataModel.class, "/freemarker-templates/");
+            // creates data model
+            HelloDataModel data = new HelloDataModel();
+            data.setName( "FreeMarker GraalVM Native Demo" );
+            data.setVersion( version.toString() );
+            log.info( String.format( "name : %s, version : %s", data.getName(), data.getVersion() ) );
+            Map<String, Object> input = new HashMap<>();
+            input.put( "data", data );
+            // process template
+            Template template = cfg.getTemplate( "hello-world.ftl" );
+            template.process( input, buffer );
+            log.info( String.format( "result :\n%s", buffer ) );
+        }
+    }
+
+}

--- a/freemarker-test-graalvm-native/src/main/resources/freemarker-templates/hello-world.ftl
+++ b/freemarker-test-graalvm-native/src/main/resources/freemarker-templates/hello-world.ftl
@@ -1,0 +1,27 @@
+<#--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<html>
+    <head>
+        <title>Hello : ${data.name}</title>
+    </head>
+    <body>
+        <h1>Hello : ${data.name}</h1>
+        <p>Test template for Apache FreeMarker GraalVM native support (${data.version})</p>
+    </body>
+</html>

--- a/freemarker-test-graalvm-native/src/test/java/org/freemarker/core/graal/HelloFreeMarkerTest.java
+++ b/freemarker-test-graalvm-native/src/test/java/org/freemarker/core/graal/HelloFreeMarkerTest.java
@@ -17,22 +17,26 @@
  * under the License.
  */
 
-rootProject.name = "freemarker-gae"
+package org.freemarker.core.graal;
 
-apply(from = rootDir.toPath().resolve("gradle").resolve("repositories.gradle.kts"))
+import freemarker.log.Logger;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
-plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention") version "0.7.0"
-}
+class HelloFreeMarkerTest {
 
-dependencyResolutionManagement {
-    versionCatalogs {
-        create("libs") {
-            version("junit", "4.12")
+    private final static Logger log = Logger.getLogger(HelloFreeMarker.class.getName());
 
-            library("junit", "junit", "junit").versionRef("junit")
+    @Test
+    public void testMain() {
+        try {
+            HelloFreeMarker.main(new String[0]);
+            Assertions.assertTrue( Boolean.TRUE );
+        } catch (Exception e) {
+            String message = String.format( "Error : %s", e );
+            log.error( message , e );
+            Assertions.fail( message );
         }
     }
-}
 
-include("freemarker-test-graalvm-native")
+}

--- a/rat-excludes
+++ b/rat-excludes
@@ -68,6 +68,10 @@ gradle/**
 .directory
 .Trash*
 
+# ignore for freemarker-test-graalvm-native module (only used for GraalVM native support compliance)
+freemarker-test-graalvm-native/build/**
+freemarker-test-graalvm-native/README.md
+
 # Well known files that need no license note:
 # -------------------------------------------
 


### PR DESCRIPTION
# Native support

In this pull request : 

## GraalVM native support

1. Added native-image.properties to initialize at runtime relevant classes
2. Added resource-config.json to track resources to include in the native executable
3. Added boolean IS_GRAALVM_NATIVE = System.getProperty( "org.graalvm.nativeimage.imagecode" ) != null in logger to avoid runtime initialization error
4. Added dependency to GraalVM SDK

## Test module

Added a test module to build as a GraalVM native image.

1. Build the main Apache FreeMarker proejct : 

```shell
./gradlew build -Pfreemarker.allowUnsignedReleaseBuild=true
```

2. Build the test module native image with GraalVM : 

```shell
./gradlew :freemarker-test-graalvm-native:nativeCompile 
```

3. Run the project :

```shell
./freemarker-test-graalvm-native/build/native/nativeCompile/freemarker-test-graalvm-native 
```

## CI

Updated CI to test the GraalVM native support by building and running the test module as a native executable.

