### PR TITLE
Disable execution for freemarker.template.utility.Execute

### DIFF
--- a/freemarker-core/src/main/java/freemarker/template/utility/Execute.java
+++ b/freemarker-core/src/main/java/freemarker/template/utility/Execute.java
@@ -61,6 +61,7 @@ import freemarker.template.TemplateModelException;
 public class Execute implements freemarker.template.TemplateMethodModel {
 
     private final static int OUTPUT_BUFFER_SIZE = 1024;
+    private final static boolean DISABLE_EXECUTE = SecurityUtilities.getSystemProperty("freemarker.template.disableExecute", null) != null;
 
     /**
      * Executes a method call.
@@ -74,6 +75,9 @@ public class Execute implements freemarker.template.TemplateMethodModel {
         String aExecute;
         StringBuilder    aOutputBuffer = new StringBuilder();
 
+        if ( DISABLE_EXECUTE ) {
+            throw new TemplateModelException( "Execution disabled" );
+        }
         if ( arguments.size() < 1 ) {
             throw new TemplateModelException( "Need an argument to execute" );
         }


### PR DESCRIPTION
This class can be used as a gadget for attack. It is suggested to make a setting to disable potentially dangerous code