### PR TITLE
Fixed error in docs for new switch-on syntax

### DIFF
--- a/freemarker-manual/src/main/docgen/en_US/book.xml
+++ b/freemarker-manual/src/main/docgen/en_US/book.xml
@@ -25359,9 +25359,8 @@ or
   &lt;#on <replaceable>refValue2, refValue3</replaceable>&gt;
     <replaceable>... (Handles both refValue2 and refValue3)</replaceable>)
   <replaceable>...</replaceable>
-  &lt;#case <replaceable>refValueN</replaceable>&gt;
+  &lt;#on <replaceable>refValueN</replaceable>&gt;
     <replaceable>...</replaceable>
-    &lt;#break&gt;
   &lt;#default&gt;
     <replaceable>...</replaceable>
 &lt;/#switch&gt;</literal></programlisting>


### PR DESCRIPTION
The example code for switch-on had a stray usage of switch-case. I've corrected this to consistently use the switch-on syntax.