### PR TITLE
add generics to TransformBlock and UnifiedCall

### DIFF
--- a/freemarker-core/src/main/java/freemarker/core/MiscUtil.java
+++ b/freemarker-core/src/main/java/freemarker/core/MiscUtil.java
@@ -20,8 +20,6 @@
 package freemarker.core;
 
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 
@@ -30,7 +28,7 @@ import java.util.Map;
  */
 class MiscUtil {
     
-    // Can't be instatiated
+    // Can't be instantiated
     private MiscUtil() { }
 
     static final String C_FALSE = "false";
@@ -39,29 +37,23 @@ class MiscUtil {
     /**
      * Returns the map entries in source code order of the Expression values.
      */
-    static List/*Map.Entry*/ sortMapOfExpressions(Map/*<?, Expression>*/ map) {
-        ArrayList res = new ArrayList(map.entrySet());
-        Collections.sort(res, 
-                new Comparator() {  // for sorting to source code order
-                    @Override
-                    public int compare(Object o1, Object o2) {
-                        Map.Entry ent1 = (Map.Entry) o1;
-                        Expression exp1 = (Expression) ent1.getValue();
-                        
-                        Map.Entry ent2 = (Map.Entry) o2;
-                        Expression exp2 = (Expression) ent2.getValue();
-                        
-                        int res = exp1.beginLine - exp2.beginLine;
-                        if (res != 0) return res;
-                        res = exp1.beginColumn - exp2.beginColumn;
-                        if (res != 0) return res;
-                        
-                        if (ent1 == ent2) return 0;
-                        
-                        // Should never reach this
-                        return ((String) ent1.getKey()).compareTo((String) ent1.getKey()); 
-                    }
-            
+    static List<Map.Entry<String, Expression>> sortMapOfExpressions(Map<String, Expression> map) {
+        ArrayList<Map.Entry<String, Expression>> res = new ArrayList<>(map.entrySet());
+        // for sorting to source code order
+        res.sort((ent1, ent2) -> {
+            Expression exp1 = ent1.getValue();
+
+            Expression exp2 = ent2.getValue();
+
+            int res1 = exp1.beginLine - exp2.beginLine;
+            if (res1 != 0) return res1;
+            res1 = exp1.beginColumn - exp2.beginColumn;
+            if (res1 != 0) return res1;
+
+            if (ent1 == ent2) return 0;
+
+            // Should never reach this
+            return (ent1.getKey()).compareTo(ent1.getKey());
         });
         return res;
     }

--- a/freemarker-core/src/main/java/freemarker/core/TransformBlock.java
+++ b/freemarker-core/src/main/java/freemarker/core/TransformBlock.java
@@ -22,12 +22,11 @@ package freemarker.core;
 import java.io.IOException;
 import java.lang.ref.Reference;
 import java.lang.ref.SoftReference;
+import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import freemarker.template.EmptyMap;
 import freemarker.template.TemplateException;
 import freemarker.template.TemplateModel;
 import freemarker.template.TemplateTransformModel;
@@ -40,14 +39,14 @@ import freemarker.template.TemplateTransformModel;
 final class TransformBlock extends TemplateElement {
 
     private Expression transformExpression;
-    Map namedArgs;
-    private transient volatile SoftReference/*List<Map.Entry<String,Expression>>*/ sortedNamedArgsCache;
+    Map<String, Expression> namedArgs;
+    private transient volatile SoftReference<List<Map.Entry<String,Expression>>> sortedNamedArgsCache;
 
     /**
      * Creates new TransformBlock, with a given transformation
      */
     TransformBlock(Expression transformExpression, 
-                   Map namedArgs,
+                   Map<String, Expression> namedArgs,
                    TemplateElements children) {
         this.transformExpression = transformExpression;
         this.namedArgs = namedArgs;
@@ -59,18 +58,17 @@ final class TransformBlock extends TemplateElement {
     throws TemplateException, IOException {
         TemplateTransformModel ttm = env.getTransform(transformExpression);
         if (ttm != null) {
-            Map args;
+            Map<String, TemplateModel> args;
             if (namedArgs != null && !namedArgs.isEmpty()) {
-                args = new HashMap();
-                for (Iterator it = namedArgs.entrySet().iterator(); it.hasNext(); ) {
-                    Map.Entry entry = (Map.Entry) it.next();
-                    String key = (String) entry.getKey();
-                    Expression valueExp = (Expression) entry.getValue();
+                args = new HashMap<>();
+                for (Map.Entry<String, Expression> entry : namedArgs.entrySet()) {
+                    String key = entry.getKey();
+                    Expression valueExp = entry.getValue();
                     TemplateModel value = valueExp.eval(env);
                     args.put(key, value);
                 }
             } else {
-                args = EmptyMap.instance;
+                args = Collections.emptyMap();
             }
             env.visitAndTransform(getChildBuffer(), ttm, args);
         } else {
@@ -90,12 +88,11 @@ final class TransformBlock extends TemplateElement {
         sb.append(' ');
         sb.append(transformExpression);
         if (namedArgs != null) {
-            for (Iterator it = getSortedNamedArgs().iterator(); it.hasNext(); ) {
-                Map.Entry entry = (Map.Entry) it.next();
+            for (Map.Entry<String, Expression> entry : getSortedNamedArgs()) {
                 sb.append(' ');
                 sb.append(entry.getKey());
                 sb.append('=');
-                _MessageUtil.appendExpressionAsUntearable(sb, (Expression) entry.getValue());
+                _MessageUtil.appendExpressionAsUntearable(sb, entry.getValue());
             }
         }
         if (canonical) {
@@ -121,7 +118,7 @@ final class TransformBlock extends TemplateElement {
         if (idx == 0) {
             return transformExpression;
         } else if (namedArgs != null && idx - 1 < namedArgs.size() * 2) {
-            Map.Entry namedArg = (Map.Entry) getSortedNamedArgs().get((idx - 1) / 2);
+            Map.Entry<String, Expression> namedArg = getSortedNamedArgs().get((idx - 1) / 2);
             return (idx - 1) % 2 == 0 ? namedArg.getKey() : namedArg.getValue();
         } else {
             throw new IndexOutOfBoundsException();
@@ -143,15 +140,15 @@ final class TransformBlock extends TemplateElement {
      * Returns the named args by source-code order; it's not meant to be used during template execution, too slow for
      * that!
      */
-    private List/*<Map.Entry<String, Expression>>*/ getSortedNamedArgs() {
-        Reference ref = sortedNamedArgsCache;
+    private List<Map.Entry<String, Expression>> getSortedNamedArgs() {
+        Reference<List<Map.Entry<String,Expression>>> ref = sortedNamedArgsCache;
         if (ref != null) {
-            List res = (List) ref.get();
+            List<Map.Entry<String, Expression>>  res = ref.get();
             if (res != null) return res;
         }
         
-        List res = MiscUtil.sortMapOfExpressions(namedArgs);
-        sortedNamedArgsCache = new SoftReference(res);
+        List<Map.Entry<String, Expression>>  res = MiscUtil.sortMapOfExpressions(namedArgs);
+        sortedNamedArgsCache = new SoftReference<>(res);
         return res;
     }
 

--- a/freemarker-core/src/main/java/freemarker/core/UnifiedCall.java
+++ b/freemarker-core/src/main/java/freemarker/core/UnifiedCall.java
@@ -22,12 +22,11 @@ package freemarker.core;
 import java.io.IOException;
 import java.lang.ref.Reference;
 import java.lang.ref.SoftReference;
+import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import freemarker.template.EmptyMap;
 import freemarker.template.TemplateDirectiveModel;
 import freemarker.template.TemplateException;
 import freemarker.template.TemplateModel;
@@ -41,15 +40,15 @@ import freemarker.template.utility.StringUtil;
 final class UnifiedCall extends TemplateElement implements DirectiveCallPlace {
 
     private Expression nameExp;
-    private Map<String, ? extends Expression> namedArgs;
-    private List<? extends Expression> positionalArgs;
+    private Map<String, Expression> namedArgs;
+    private List<Expression> positionalArgs;
     private List<String> bodyParameterNames;
     boolean legacySyntax;
-    private transient volatile SoftReference/*List<Map.Entry<String,Expression>>*/ sortedNamedArgsCache;
+    private transient volatile SoftReference<List<Map.Entry<String,Expression>>> sortedNamedArgsCache;
     private CustomDataHolder customDataHolder;
 
     UnifiedCall(Expression nameExp,
-         Map<String, ? extends Expression> namedArgs,
+         Map<String, Expression> namedArgs,
          TemplateElements children,
          List<String> bodyParameterNames) {
         this.nameExp = nameExp;
@@ -59,7 +58,7 @@ final class UnifiedCall extends TemplateElement implements DirectiveCallPlace {
     }
 
     UnifiedCall(Expression nameExp,
-         List<? extends Expression> positionalArgs,
+         List<Expression> positionalArgs,
          TemplateElements children,
          List<String> bodyParameterNames) {
         this.nameExp = nameExp;
@@ -84,18 +83,17 @@ final class UnifiedCall extends TemplateElement implements DirectiveCallPlace {
         } else {
             boolean isDirectiveModel = tm instanceof TemplateDirectiveModel; 
             if (isDirectiveModel || tm instanceof TemplateTransformModel) {
-                Map args;
+                Map<String, TemplateModel> args;
                 if (namedArgs != null && !namedArgs.isEmpty()) {
-                    args = new HashMap();
-                    for (Iterator it = namedArgs.entrySet().iterator(); it.hasNext(); ) {
-                        Map.Entry entry = (Map.Entry) it.next();
-                        String key = (String) entry.getKey();
-                        Expression valueExp = (Expression) entry.getValue();
+                    args = new HashMap<>();
+                    for (Map.Entry<String, Expression> entry : namedArgs.entrySet()) {
+                        String key = entry.getKey();
+                        Expression valueExp = entry.getValue();
                         TemplateModel value = valueExp.eval(env);
                         args.put(key, value);
                     }
                 } else {
-                    args = EmptyMap.instance;
+                    args = Collections.emptyMap();
                 }
                 if (isDirectiveModel) {
                     env.visit(getChildBuffer(), (TemplateDirectiveModel) tm, args, bodyParameterNames);
@@ -128,12 +126,11 @@ final class UnifiedCall extends TemplateElement implements DirectiveCallPlace {
                 sb.append(argExp.getCanonicalForm());
             }
         } else {
-            List entries = getSortedNamedArgs();
-            for (int i = 0; i < entries.size(); i++) {
-                Map.Entry entry = (Map.Entry) entries.get(i);
-                Expression argExp = (Expression) entry.getValue();
+            List<Map.Entry<String, Expression>> entries = getSortedNamedArgs();
+            for (Map.Entry<String, Expression> entry : entries) {
+                Expression argExp = entry.getValue();
                 sb.append(' ');
-                sb.append(_CoreStringUtils.toFTLTopLevelIdentifierReference((String) entry.getKey()));
+                sb.append(_CoreStringUtils.toFTLTopLevelIdentifierReference(entry.getKey()));
                 sb.append('=');
                 _MessageUtil.appendExpressionAsUntearable(sb, argExp);
             }
@@ -191,7 +188,7 @@ final class UnifiedCall extends TemplateElement implements DirectiveCallPlace {
                 base += positionalArgsSize;
                 final int namedArgsSize = namedArgs != null ? namedArgs.size() : 0;
                 if (idx - base < namedArgsSize * 2) {
-                    Map.Entry namedArg = (Map.Entry) getSortedNamedArgs().get((idx - base) / 2);
+                    Map.Entry<String, Expression> namedArg = getSortedNamedArgs().get((idx - base) / 2);
                     return (idx - base) % 2 == 0 ? namedArg.getKey() : namedArg.getValue();
                 } else {
                     base += namedArgsSize * 2;
@@ -237,15 +234,15 @@ final class UnifiedCall extends TemplateElement implements DirectiveCallPlace {
      * Returns the named args by source-code order; it's not meant to be used during template execution, too slow for
      * that!
      */
-    private List/*<Map.Entry<String, Expression>>*/ getSortedNamedArgs() {
-        Reference ref = sortedNamedArgsCache;
+    private List<Map.Entry<String, Expression>> getSortedNamedArgs() {
+        Reference<List<Map.Entry<String,Expression>>> ref = sortedNamedArgsCache;
         if (ref != null) {
-            List res = (List) ref.get();
+            List<Map.Entry<String, Expression>>  res = ref.get();
             if (res != null) return res;
         }
-        
-        List res = MiscUtil.sortMapOfExpressions(namedArgs);
-        sortedNamedArgsCache = new SoftReference(res);
+
+        List<Map.Entry<String, Expression>> res = MiscUtil.sortMapOfExpressions(namedArgs);
+        sortedNamedArgsCache = new SoftReference<>(res);
         return res;
     }
 

--- a/freemarker-core/src/main/javacc/freemarker/core/FTL.jj
+++ b/freemarker-core/src/main/javacc/freemarker/core/FTL.jj
@@ -3604,8 +3604,9 @@ CompressedBlock Compress() :
 TemplateElement UnifiedMacroTransform() :
 {
     Token start = null, end, t;
-    HashMap namedArgs = null;
-    ArrayList positionalArgs = null, bodyParameters = null;
+    HashMap<String, Expression> namedArgs = null;
+    ArrayList<Expression> positionalArgs = null;
+    ArrayList<String> bodyParameters = null;
     Expression startTagNameExp;
     TemplateElements children;
     Expression exp;
@@ -3639,7 +3640,7 @@ TemplateElement UnifiedMacroTransform() :
     )
     [
         <SEMICOLON>
-        { bodyParameters = new ArrayList(4); }
+        { bodyParameters = new ArrayList<>(4); }
         [
             [<TERMINATING_WHITESPACE>] t = <ID> { bodyParameters.add(t.image); }
             (
@@ -3709,8 +3710,8 @@ TemplateElement UnifiedMacroTransform() :
 TemplateElement Call() :
 {
     Token start, end, id;
-    HashMap namedArgs = null;
-    ArrayList positionalArgs = null;
+    HashMap<String, Expression> namedArgs = null;
+    ArrayList<Expression> positionalArgs = null;
     Identifier macroName= null;
 }
 {
@@ -3746,9 +3747,9 @@ TemplateElement Call() :
     }
 }
 
-HashMap NamedArgs() :
+HashMap<String, Expression> NamedArgs() :
 {
-    HashMap result = new HashMap();
+    HashMap<String, Expression> result = new HashMap<>();
     Token t;
     Expression exp;
 }
@@ -3771,9 +3772,9 @@ HashMap NamedArgs() :
     }
 }
 
-ArrayList PositionalArgs() :
+ArrayList<Expression> PositionalArgs() :
 {
-    ArrayList result = new ArrayList();
+    ArrayList<Expression> result = new ArrayList<>();
     Expression arg;
 }
 {
@@ -3850,7 +3851,7 @@ TransformBlock Transform() :
     Token start, end, argName;
     Expression exp, argExp;
     TemplateElements children = null;
-    HashMap args = null;
+    HashMap<String, Expression> args = null;
 }
 {
     start = <TRANSFORM>
@@ -3861,7 +3862,7 @@ TransformBlock Transform() :
         <EQUALS>
         argExp = Expression()
         {
-            if (args == null) args = new HashMap();
+            if (args == null) args = new HashMap<>();
             args.put(argName.image, argExp);
         }
     )*


### PR DESCRIPTION
I added the missing generics to `TransformBlock` and `UnifiedCall`. Remove the wildcard (`?`) spread in `UnifiedCall` introduced in54905b601b467692fd8f9c25618fd7e524d00acb,as no caller passes a list with a subclass type.
Also add missing generics to `MiscUtil.sortMapOfExpressions` and in the `FRL.jj`.