### PR TITLE
[FREEMARKER-209] Fix "estabilished" typo in error message

### DIFF
--- a/freemarker-core/src/main/javacc/freemarker/core/FTL.jj
+++ b/freemarker-core/src/main/javacc/freemarker/core/FTL.jj
@@ -677,7 +677,7 @@ TOKEN_MGR_DECLS:
         }
         
         if (!strictSyntaxMode) {
-            // Legacy feature (or bug?): Tag syntax never gets estabilished in non-strict mode.
+            // Legacy feature (or bug?): Tag syntax never gets established in non-strict mode.
             // We do establish the naming convention though.
             checkNamingConvention(tok, tokenNamingConvention);
             SwitchTo(newLexState);
@@ -748,7 +748,7 @@ TOKEN_MGR_DECLS:
                                     : "??? (internal error)"
                                     ))
                 + (namingConventionEstabilisher != null
-                        ? "estabilished by auto-detection at "
+                        ? "established by auto-detection at "
                             + _MessageUtil.formatPosition(
                                     namingConventionEstabilisher.beginLine, namingConventionEstabilisher.beginColumn)
                             + " by token " + StringUtil.jQuote(namingConventionEstabilisher.image.trim())


### PR DESCRIPTION
## Summary

Fixes [FREEMARKER-209](https://issues.apache.org/jira/browse/FREEMARKER-209) — the naming-convention mismatch error message emitted by the FTL parser contains the misspelling "estabilished". This PR corrects it to "established" and also fixes the same typo in a related code comment a few lines above.

## Changes

- `freemarker-core/src/main/javacc/freemarker/core/FTL.jj:680` — comment
- `freemarker-core/src/main/javacc/freemarker/core/FTL.jj:751` — user-facing error message

Two-line diff in a single file. No test or identifier changes.

## Scope note

The same typo also appears in the field name `namingConventionEstabilisher` (FTL.jj:647 and six usages). I left that rename out of this PR to keep the diff minimal and scoped to the ticket. Happy to do it as a follow-up if maintainers prefer.

## Verification

- `./gradlew build` passes locally (JDK 21, since Gradle 8.5 doesn't recognize newer JDKs).
- Regenerated `FMParserTokenManager.java` contains the corrected string.
- `CamelCaseTest` exercises this exact error path; its assertions still pass because they don't pin the misspelling.

## Test plan

- [x] `./gradlew build` succeeds
- [x] Generated parser contains `"established by auto-detection at "`
- [x] No remaining `estabilished` in build output