### PR TITLE
[FREEMARKER-116] Fix mismatch between example code and explanation in BeansWrapper documentation

### DIFF
--- a/freemarker-manual/src/main/docgen/en_US/book.xml
+++ b/freemarker-manual/src/main/docgen/en_US/book.xml
@@ -11295,7 +11295,7 @@ TemplateHashModel fileStatics =
 
           <para>And you will get a template hash model that exposes all static
           methods and static fields (both final and non-final) of the
-          <literal>java.lang.System</literal> class as hash keys. Suppose that
+          <literal>java.io.File</literal> class as hash keys. Suppose that
           you put the previous model in your root model:</para>
 
           <programlisting role="unspecified">root.put("File", fileStatics);</programlisting>


### PR DESCRIPTION
## Summary
- Fix a copy/paste leftover in the FreeMarker Manual's "Accessing static methods" section where the code example retrieves statics for `java.io.File` but the following paragraph referred to `java.lang.System`.
- The subsequent examples in the same section (`root.put("File", fileStatics)`, `${File.SEPARATOR}`, `File.listRoots()`) confirm `java.io.File` is the intended class.

Resolves [FREEMARKER-116](https://issues.apache.org/jira/browse/FREEMARKER-116).

## Test plan
- [x] Docs-only change; verified the surrounding paragraphs and examples reference `java.io.File` consistently after the fix.
